### PR TITLE
Handle UnsatisfiedAssumption in server request handler

### DIFF
--- a/src/hegel/hegeld.py
+++ b/src/hegel/hegeld.py
@@ -18,7 +18,7 @@ from typing import Any
 from hypothesis import settings
 from hypothesis.control import BuildContext
 from hypothesis.database import DirectoryBasedExampleDatabase
-from hypothesis.errors import StopTest
+from hypothesis.errors import StopTest, UnsatisfiedAssumption
 from hypothesis.internal.cache import LRUCache
 from hypothesis.internal.conjecture.data import ConjectureData, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner
@@ -114,6 +114,9 @@ def make_test_function(
                             )
                     else:
                         raise ValueError(f"Unknown command: {command}")
+                except UnsatisfiedAssumption:
+                    done = True
+                    data.mark_invalid()
                 except StopTest:
                     done = True
                     raise

--- a/tests/test_hegeld_coverage.py
+++ b/tests/test_hegeld_coverage.py
@@ -6,6 +6,7 @@ from threading import Thread
 from unittest.mock import patch
 
 import pytest
+from hypothesis import strategies as st
 
 from hegel.hegeld import (
     CACHE_SIZE,
@@ -221,6 +222,43 @@ def test_mark_interesting_status():
 
         with pytest.raises(AssertionError):
             client.run_test("test_mark_interesting", my_test, test_cases=20)
+    finally:
+        client_connection.close()
+
+    thread.join(timeout=5)
+
+
+def test_unsatisfied_assumption_handled_gracefully():
+    """Test that UnsatisfiedAssumption from data.draw() is handled as invalid.
+
+    When a Hypothesis strategy raises UnsatisfiedAssumption (e.g., st.nothing()),
+    the server should call data.mark_invalid() instead of crashing. This converts
+    it to a StopTest which the SDK handles as DataExhausted.
+    """
+    server_socket, client_socket = socket.socketpair()
+    thread = Thread(
+        target=run_server_on_connection,
+        args=(Connection(server_socket, name="Server"),),
+        daemon=True,
+    )
+    thread.start()
+
+    try:
+        client_connection = Connection(client_socket, name="Client")
+        client = Client(client_connection)
+
+        def my_test():
+            # st.nothing() always raises UnsatisfiedAssumption when drawn.
+            # The server should handle this gracefully by marking the test
+            # case as invalid rather than crashing.
+            generate_from_schema({"type": "integer"})
+
+        # Mock cached_from_schema to return st.nothing(), which always
+        # raises UnsatisfiedAssumption on draw.
+        with patch("hegel.hegeld.cached_from_schema", return_value=st.nothing()):
+            # All test cases will be marked invalid (UnsatisfiedAssumption),
+            # so no interesting examples are found and the test "passes".
+            client.run_test("test_unsatisfied", my_test, test_cases=10)
     finally:
         client_connection.close()
 


### PR DESCRIPTION
## Summary

- Catch `UnsatisfiedAssumption` in `handle_sdk_request` and call `data.mark_invalid()` instead of letting it propagate
- Fixes server crash when `data.draw(strategy)` raises `UnsatisfiedAssumption` (e.g., from `floats(width=32)` internal filtering)
- Previously, the exception propagated to `handle_requests` which called `send_response_error(id, e)`, but `UnsatisfiedAssumption()` has no args, causing `IndexError: tuple index out of range` in `send_response_error`

## Test plan

- [x] Added `test_unsatisfied_assumption_handled_gracefully` that mocks `cached_from_schema` to return `st.nothing()` (always raises `UnsatisfiedAssumption`) and verifies the test completes without crashing
- [x] All 238 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)