### PR TITLE
Run reader directly rather than using a dispatcher thread

### DIFF
--- a/src/hegel/protocol.py
+++ b/src/hegel/protocol.py
@@ -36,7 +36,8 @@ from collections import deque
 from dataclasses import dataclass
 from enum import Enum
 from queue import Empty, SimpleQueue
-from threading import Lock, Thread, current_thread
+from threading import Lock
+from time import sleep, time
 from typing import Any, NewType
 
 import cbor2
@@ -80,18 +81,18 @@ TERMINATOR = 0x0A  # '\n'
 REPLY_BIT = 1 << 31
 
 
+ChannelId = NewType("ChannelId", int)
+MessageId = NewType("MessageId", int)
+
 # Special payload that is sent on a channel when it is shut down. The shutdown
-# is not acked and is handled specifically
+# is not acked and is handled specifially.
 # Chosen to be invalid CBOR as per https://www.rfc-editor.org/rfc/rfc8949.html
 # It is currently also not the prefix of any valid CBOR (this is a reserved)
 # tag byte) but even if it became valid in future this would not be a problem.
-CLOSE_CHANNEL_MESSAGE_ID = (1 << 31) - 1
 CLOSE_CHANNEL_PAYLOAD = bytes([0b11111110])
+CLOSE_CHANNEL_MESSAGE_ID = MessageId((1 << 31) - 1)
 
 SHUTDOWN = UniqueIdentifier("shutdown")
-
-ChannelId = NewType("ChannelId", int)
-MessageId = NewType("MessageId", int)
 
 
 @dataclass(frozen=True, slots=True)
@@ -124,9 +125,11 @@ def recv_exact(sock: socket.socket, n: int) -> bytes:
     return bytes(data)
 
 
-def read_packet(sock: socket.socket) -> Packet:
+def read_packet(sock: socket.socket, timeout: float | None = None) -> Packet:
     """Read and parse a single packet from the socket."""
+    sock.settimeout(timeout)
     header = recv_exact(sock, struct.calcsize(HEADER_FORMAT))
+    sock.settimeout(None)
     magic, checksum, channel, message_id, length = struct.unpack(HEADER_FORMAT, header)
 
     is_reply = message_id & REPLY_BIT != 0
@@ -204,22 +207,17 @@ class Connection:
         self.__next_channel_id = 1
         self.channels = {}
         self.__running = True
-        self.__lock = Lock()
         if debug is None:
             debug = _is_protocol_debug()
         self._debug = debug
+        self.__writer_lock = Lock()
+        self.__reader_lock = Lock()
         self.__connection_state = ConnectionState.UNRESOLVED
-        # Control channel must be created before the reader thread starts,
-        # otherwise an incoming packet for channel 0 could arrive before
-        # the channel is registered and be treated as a non-existent channel.
         self.__control_channel = self.new_channel(role="Control")
-        self.__threads = [Thread(target=self.__run_reader, daemon=True)]
-        for t in self.__threads:
-            t.start()
 
     @property
     def live(self):
-        return self.__running and all(t.is_alive() for t in self.__threads)
+        return self.__running
 
     @classmethod
     def create_server(cls, address, **kwargs):
@@ -259,10 +257,26 @@ class Connection:
             f" {reply}: {payload_repr!r}",
         )
 
-    def __run_reader(self):
+    def run_reader(self, until):
+        if until():
+            return
+        acquired = False
         try:
-            while self.__running:
-                packet = read_packet(self.__socket)
+            while True:
+                acquired = self.__reader_lock.acquire(blocking=False)
+                if acquired:
+                    break
+                elif until():
+                    return
+                else:
+                    # Very short sleep to avoid busy waiting
+                    sleep(0.001)
+
+            while self.__running and not until():
+                try:
+                    packet = read_packet(self.__socket, timeout=0.1)
+                except TimeoutError:
+                    continue
                 channel = self.channels.get(packet.channel_id)
                 channel_name = (
                     f"channel {packet.channel_id}" if channel is None else channel.name
@@ -303,16 +317,14 @@ class Connection:
                             )
                     else:
                         channel.inbox.put(packet)
-        except ConnectionError:
-            pass
-        except Exception:
-            traceback.print_exc()
+                        assert not channel.inbox.empty()
         finally:
-            self.close()
+            if acquired:
+                self.__reader_lock.release()
 
     def send_packet(self, packet: Packet) -> None:
         """Send a packet to the peer, thread-safe."""
-        with self.__lock:
+        with self.__writer_lock:
             self._debug_packet("SEND", packet)
             write_packet(self.__socket, packet)
 
@@ -325,11 +337,6 @@ class Connection:
         with contextlib.suppress(OSError):
             self.__socket.shutdown(socket.SHUT_RDWR)
         self.__socket.close()
-
-        current = current_thread()
-        for t in self.__threads:
-            if t is not current:
-                t.join(timeout=0.1)
 
         for v in self.channels.values():
             if not isinstance(v, DeadChannel):
@@ -386,7 +393,7 @@ class Connection:
             self.__next_channel_id += 1
 
         result = Channel(connection=self, channel_id=channel_id, role=role)
-        with self.__lock:
+        with self.__writer_lock:
             self.channels[result.channel_id] = result
         return result
 
@@ -402,7 +409,7 @@ class Connection:
         assert id & 1 != int(self.__connection_state == ConnectionState.CLIENT)
 
         result = Channel(connection=self, channel_id=id, role=role)
-        with self.__lock:
+        with self.__writer_lock:
             self.channels[result.channel_id] = result
         return result
 
@@ -501,12 +508,21 @@ class Channel:
                 f"{self.connection.name} channel [id={self.channel_id}] ({self.role})"
             )
 
-    def __process_one_message(self, *, timeout=CHANNEL_TIMEOUT):
+    def __needs_messages(self):
+        return (not self.__closed) and self.inbox.empty()
+
+    def __process_one_message(self, timeout: float | None = CHANNEL_TIMEOUT) -> None:
         """Route an incoming message to responses or requests queue."""
+        start = time()
+        self.connection.run_reader(
+            until=lambda: self.__closed
+            or (timeout is not None and time() - start > timeout)
+            or not self.__needs_messages()
+        )
         if self.__closed:
             raise ConnectionError(f"{self.name} is closed")
         try:
-            packet = self.inbox.get(timeout=timeout)
+            packet = self.inbox.get_nowait()
         except Empty:
             raise TimeoutError(
                 f"Timed out after {timeout}s waiting for a message on {self.name}",
@@ -609,7 +625,7 @@ class Channel:
     def send_response_error(
         self,
         message_id: MessageId,
-        message: Exception | None = None,
+        message: BaseException | None = None,
         *,
         error: str | None = None,
         error_type: str | None = None,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -7,9 +7,9 @@ from threading import Thread
 
 import cbor2
 import pytest
-from client import Client
 
 from hegel.protocol import (
+    SHUTDOWN,
     Connection,
     DeadChannel,
     Packet,
@@ -17,7 +17,6 @@ from hegel.protocol import (
     result_or_error,
     write_packet,
 )
-from hegel.server import run_server_on_connection
 
 
 def _handshake_pair(server_conn, client_conn):
@@ -124,8 +123,11 @@ def test_message_to_nonexistent_channel(socket_pair):
     )
     client_conn.send_packet(packet)
 
-    # The server should auto-reply with an error
-    time.sleep(0.2)
+    # Also send a control channel message so the server has something to
+    # receive — the reader will process the channel-999 packet first
+    # (sending back an error reply) then deliver the control message.
+    client_conn.control_channel.send_request_raw(b"ping")
+    server_conn.control_channel.receive_request_raw()
     server_conn.close()
     client_conn.close()
 
@@ -669,24 +671,6 @@ def test_send_handshake_bad_response(socket_pair):
         client_conn.close()
 
 
-def test_concurrent_connection_handshake():
-    for _ in range(20):
-        server_socket, client_socket = socket.socketpair()
-
-        def server(ss=server_socket):
-            run_server_on_connection(Connection(ss, name="Server"))
-
-        t = Thread(target=server, daemon=True)
-        t.start()
-
-        conn = Connection(client_socket, name="Client")
-        client = Client(conn)
-
-        client.run_test("test", lambda: None, test_cases=1)
-        conn.close()
-        t.join(timeout=5)
-
-
 # ---- Connection lifecycle ----
 
 
@@ -697,6 +681,26 @@ def test_connection_live(socket_pair):
     assert conn.live
     conn.close()
     assert not conn.live
+
+
+def test_connection_double_close(socket_pair):
+    """Test that closing an already-closed connection is a no-op."""
+    server_socket, _client_socket = socket_pair
+    conn = Connection(server_socket, name="DoubleClose")
+    conn.close()
+    # Second close should return early
+    conn.close()
+
+
+def test_shutdown_in_inbox_raises(socket_pair):
+    """Test that SHUTDOWN in inbox raises ConnectionError."""
+    server_socket, _client_socket = socket_pair
+    conn = Connection(server_socket, name="Test")
+    ch = conn.control_channel
+    ch.inbox.put(SHUTDOWN)
+    with pytest.raises(ConnectionError, match="Connection closed"):
+        ch.receive_request(timeout=0.1)
+    conn.close()
 
 
 def test_create_server():


### PR DESCRIPTION
The previous design of the connection required us to run a background dispatcher thread. This is kinda a pain in the ass, masks a bunch of errors, and makes it harder to port the SDK pattern to other languages.

This changes it so that we run the dispatcher loop in the current thread, for just long enough to get a message dispatched to us. This has much the same effect, with less thread orchestration.