### PR TITLE
Fix release workflow: add missing checks: read permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
+      checks: read
       contents: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- The release workflow calls `gh api repos/.../check-runs` to verify all CI workflows passed before releasing, but was missing `checks: read` permission
- This caused a 403 "Resource not accessible by integration" error on every release attempt since the CI split in 620682b
- Adds the missing `checks: read` permission to the release job

## Test plan
- [ ] Verify the release workflow no longer fails with a 403 on the check-runs API call
- [ ] Confirm the workflow still correctly skips release when not all checks have passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)