### PR TITLE
Fix release workflow: persist credentials for app token checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check all required workflows passed
+      - name: Check release preconditions
+        id: check
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -31,13 +32,11 @@ jobs:
             --paginate --jq '.check_runs[] | select(.name != "release") | .conclusion')
           if echo "$CHECKS" | grep -qvE '^success$'; then
             echo "Not all checks passed yet, skipping release"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-
-      - name: Check for RELEASE.md
-        id: check
-        run: |
           if [ ! -f RELEASE.md ]; then
+            echo "No RELEASE.md found, skipping release"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -49,7 +48,7 @@ jobs:
           app-id: ${{ vars.HEGEL_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEGEL_RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Re-checkout with app token
+      - name: Re-checkout with app token # zizmor: ignore[artipacked]
         if: steps.check.outputs.skip != 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:


### PR DESCRIPTION
## Summary

Fixes three issues in the release workflow introduced by the CI split (620682b):

- **`persist-credentials: false` on app-token checkout** prevented `git push` during release (`fatal: could not read Username`). Removed it since this checkout intentionally provides push credentials
- **Skip logic bug**: the "check all workflows passed" step used `exit 0` to skip, but that only exited the shell step — subsequent steps still ran, meaning a release could proceed before all workflows passed. Consolidated both precondition checks (all workflows passed + RELEASE.md exists) into a single step with a `skip` output that gates all later steps
- **zizmor `artipacked` warning**: added inline `zizmor: ignore[artipacked]` since we intentionally need credentials persisted for the push

Follow-up to #29 which fixed the `checks: read` permission issue.

## Test plan
- [x] zizmor check passes (artipacked suppressed)
- [ ] Verify the release workflow can successfully push the version bump commit and tags (can only be tested on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)