### PR TITLE
Update SDK API spec and test client for InvalidArgument errors

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+Update SDK API spec to document InvalidArgument error handling requirements.
+Update test client to convert InvalidArgument/ValueError errors from generate.

--- a/docs/sdk-api.md
+++ b/docs/sdk-api.md
@@ -613,11 +613,29 @@ Hegel will try different inputs.
 
 ### Error Categories
 
-| Error Type | Action |
-|------------|--------|
-| JSON parse error | `assume(false)` |
-| Server returns error | `assume(false)` |
-| Filter exhaustion | `assume(false)` |
+| Error Type | Source | Action |
+|------------|--------|--------|
+| JSON parse error | generate | `assume(false)` |
+| Server returns error (generic) | any command | `assume(false)` |
+| `InvalidArgument` error | generate | Raise as SDK-level `InvalidArgument` exception/panic |
+| Filter exhaustion | client-side | `assume(false)` |
+
+### InvalidArgument Errors
+
+The `generate()` call may raise an `InvalidArgument` error when the server
+detects that the generator arguments are contradictory (e.g.,
+`integers(min_value=10, max_value=5)`).
+
+When the SDK receives a `RequestError` with `error_type` of `"InvalidArgument"`
+from a `generate` command, it must convert this into an SDK-level
+`InvalidArgument` exception (or equivalent in the target language) rather than
+treating it as a generic error.
+
+Shrinking still applies to `InvalidArgument` errors: the arguments leading to
+the invalid state might themselves be generated data. The server will mark the
+test case as INTERESTING and shrink it, replaying the final (minimized) test
+case with `is_final=True`. On the final run, the SDK should let the
+`InvalidArgument` exception propagate to the user.
 
 ### Filter Implementation
 

--- a/tests/client.py
+++ b/tests/client.py
@@ -34,6 +34,10 @@ class DataExhausted(Exception):
     """Raised when the server runs out of test data (StopTest)."""
 
 
+class InvalidArgument(Exception):
+    """Raised when invalid arguments are passed to a generator."""
+
+
 class Client:
     """Test client for connecting to a Hegel server."""
 
@@ -226,7 +230,12 @@ def _request(payload: dict) -> Any:
 
 def generate_from_schema(schema: dict) -> Any:
     """Generate a value from a schema."""
-    return _request({"command": "generate", "schema": schema})
+    try:
+        return _request({"command": "generate", "schema": schema})
+    except RequestError as e:
+        if e.error_type == "InvalidArgument":
+            raise InvalidArgument(str(e)) from e
+        raise
 
 
 def assume(condition: bool) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 from client import (
     Client,
+    InvalidArgument,
     _request,
     assume,
     collection,
@@ -359,3 +360,23 @@ def test_pool_generate_with_mostly_removed_variables(client):
         assert result == variables[-1]
 
     client.run_test("test_pool_mostly_removed", test, test_cases=50)
+
+
+def test_invalid_argument_contradictory_bounds(client):
+    """Test that contradictory bounds raise InvalidArgument."""
+
+    def test():
+        with pytest.raises(InvalidArgument):
+            generate_from_schema({"type": "integer", "min_value": 10, "max_value": 5})
+
+    client.run_test("test_invalid_bounds", test, test_cases=1)
+
+
+def test_unsupported_schema_type_raises_request_error(client):
+    """Test that unsupported schema types raise RequestError (server sends ValueError)."""
+
+    def test():
+        with pytest.raises(RequestError):
+            generate_from_schema({"type": "unsupported_type"})
+
+    client.run_test("test_unsupported_schema", test, test_cases=1)


### PR DESCRIPTION
## Summary

- Update test client to convert `RequestError` with `error_type="InvalidArgument"` to a proper `InvalidArgument` exception in `generate_from_schema()`
- Add server-side tests for contradictory bounds (`min_value=10, max_value=5`) and unsupported schema types through the real ConjectureRunner
- Update SDK API spec to document `InvalidArgument` error handling requirements for all SDKs

## Test plan

- [ ] `just ci` passes (lint + typecheck + 100% coverage)
- [ ] Server-side tests confirm `InvalidArgument` is raised for contradictory integer bounds
- [ ] Existing `test_unknown_command_on_data_channel` still raises `RequestError` (not converted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)