### PR TITLE
Add basic support for running on Antithesis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,64 @@ jobs:
       - name: Run tests with coverage
         run: coverage run -m pytest
       - run: coverage combine
+      - name: Upload coverage data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-normal
+          path: .coverage
+          include-hidden-files: true
+
+  test-antithesis:
+    name: tests (antithesis)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install --group dev -e .
+      - name: Run tests with coverage
+        run: coverage run -m pytest
+        env:
+          ANTITHESIS_OUTPUT_DIR: ${{ runner.temp }}/antithesis-output
+      - run: coverage combine
+      - name: Upload coverage data
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: coverage-antithesis
+          path: .coverage
+          include-hidden-files: true
+
+  check-coverage:
+    name: check coverage
+    needs: [test, test-antithesis]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: pip install --group dev -e .
+      - name: Download coverage data
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: coverage-*
+          merge-multiple: false
+      - name: Combine coverage
+        run: |
+          cp coverage-normal/.coverage .coverage.normal
+          cp coverage-antithesis/.coverage .coverage.antithesis
+          coverage combine
       - name: Check coverage is 100%
         run: coverage report
 
@@ -90,7 +148,7 @@ jobs:
   release:
     name: release
     if: github.event_name == 'push' && github.repository == 'antithesishq/hegel-core'
-    needs: [lint, test, typecheck]
+    needs: [lint, check-coverage, typecheck]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+Add absolute barebones requirement for Antithesis support: If the ANTITHESIS_OUTPUT_DIR
+environment variable is set (indicating that we are running on the Antithesis system),
+use the hypothesis-urandom backend, which will get its entropy from the Antithesis fuzzer.

--- a/justfile
+++ b/justfile
@@ -5,6 +5,7 @@ test:
 
 coverage:
     uv run coverage run -m pytest tests
+    ANTITHESIS_OUTPUT_DIR="$HOME/antithesis-output" uv run coverage run -m pytest tests
     uv run coverage combine
     uv run coverage report
 

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -285,6 +285,11 @@ def _run_one(
             settings=settings(
                 deadline=None,
                 max_examples=test_cases,
+                backend=(
+                    "hypothesis-urandom"
+                    if os.environ.get("ANTITHESIS_OUTPUT_DIR")
+                    else "hypothesis"
+                ),
             ),
             random=Random(seed),
             database_key=database_key,

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "hegel"
-version = "0.3.3"
+version = "0.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "cbor2" },


### PR DESCRIPTION
This ensures that the fuzzer can control the randomness used by Hegel. It's really the absolute bare minimum required, and this is mostly a placeholder in lieu of proper support.

We might want to think harder about this before the release. For example:

* We might want to override the test cases setting so it only runs one test case on Antithesis (running more is not really useful! The fuzzer should restart instead) 
* We might want to disable the database on Antithesis.
* We might want to actually write stuff to this output dir (e.g. Tyche style observability)

This PR does none of that, because that all requires thought and decision-making, while "Should we use the Antithesis fuzzer when running on Antithesis? Y/N" is much more of a no-brainer.