### PR TITLE
Correct release commit attribution

### DIFF
--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -128,12 +128,15 @@ def release() -> None:
 
     add_changelog(ROOT / "CHANGELOG.md", version=new_version, content=content)
 
-    git("config", "user.name", "hegel-release[bot]", cwd=ROOT)
-    app_id = os.environ["HEGEL_RELEASE_APP_ID"]
+    app_slug = os.environ["HEGEL_RELEASE_APP_SLUG"]
+    bot_user_id = subprocess.check_output(
+        ["gh", "api", f"/users/{app_slug}[bot]", "--jq", ".id"], text=True
+    ).strip()
+    git("config", "user.name", f"{app_slug}[bot]", cwd=ROOT)
     git(
         "config",
         "user.email",
-        f"{app_id}+hegel-release[bot]@users.noreply.github.com",
+        f"{bot_user_id}+{app_slug}[bot]@users.noreply.github.com",
         cwd=ROOT,
     )
     git("add", "pyproject.toml", "CHANGELOG.md", cwd=ROOT)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          HEGEL_RELEASE_APP_ID: ${{ vars.HEGEL_RELEASE_APP_ID }}
+          HEGEL_RELEASE_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: python .github/scripts/release.py release
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
Part of https://github.com/hegeldev/hegel-core/issues/50. Apparently the correct way to configure github apps for commit attribution is with their user id, which is distinct from their app id.

Here is an example of an incorrect attribution (no profile picture or backlink to profile): https://github.com/hegeldev/hegel-core/commit/7449fbf214e1175d4dbdaaa0956d23dc4df45e5f