### PR TITLE
Change string tag from 6 to 24

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+Change HEGEL_STRING_TAG from 6 to 24.

--- a/src/hegel/schema.py
+++ b/src/hegel/schema.py
@@ -22,7 +22,7 @@ class BooleansStrategy(SearchStrategy[bool]):
 
 
 # used to allow encoding of surrogate code points. See https://github.com/hegeldev/hegel-core/pull/72
-HEGEL_STRING_TAG = 6
+HEGEL_STRING_TAG = 24
 
 
 def _encode_value(value: object) -> object:


### PR DESCRIPTION
nlohmann in hegel-cpp drops tags besides [24, 27]. As a result, `is_string()` in hegel-cpp was relying on a brittle `is_binary()` check instead of actually checking that the tag matched the HEGEL_STRING_TAG.