### PR TITLE
Move string tag to 91

### DIFF
--- a/.github/scripts/dispatch_to_libraries.py
+++ b/.github/scripts/dispatch_to_libraries.py
@@ -16,7 +16,7 @@ def get_version() -> str:
 
 def get_protocol_version() -> str:
     text = (ROOT / "src" / "hegel" / "protocol" / "connection.py").read_text()
-    m = re.search(r"^PROTOCOL_VERSION\s*=\s*([\d.]+)", text, re.MULTILINE)
+    m = re.search(r'^PROTOCOL_VERSION\s*=\s*"([\d.]+)"', text, re.MULTILINE)
     assert m is not None
     return m.group(1)
 

--- a/.github/scripts/release.py
+++ b/.github/scripts/release.py
@@ -82,7 +82,7 @@ def _check_protocol_version_bumped(base_ref: str) -> None:
         text=True,
         cwd=ROOT,
     )
-    if not re.search(r"^\+.*PROTOCOL_VERSION\s*=", diff, re.MULTILINE):
+    if not re.search(r'^\+.*PROTOCOL_VERSION\s*=\s*"', diff, re.MULTILINE):
         raise ValueError("Minor releases must bump PROTOCOL_VERSION.")
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,5 @@
+RELEASE_TYPE: minor
+
+This patch changes our CBOR tag for text fields from `6` to `91`, to avoid reserving a "Standards Action" tag, even though it is technically unassigned. See https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml.
+
+The protocol version is now `0.10`.

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -19,7 +19,7 @@ from hegel.protocol.utils import SHUTDOWN, ConnectionClosedError, StreamId
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
 
-PROTOCOL_VERSION = 0.9
+PROTOCOL_VERSION = "0.10"
 HANDSHAKE_STRING = b"hegel_handshake_start"
 
 

--- a/src/hegel/schema.py
+++ b/src/hegel/schema.py
@@ -22,7 +22,7 @@ class BooleansStrategy(SearchStrategy[bool]):
 
 
 # used to allow encoding of surrogate code points. See https://github.com/hegeldev/hegel-core/pull/72
-HEGEL_STRING_TAG = 6
+HEGEL_STRING_TAG = 91
 
 
 def _encode_value(value: object) -> object:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -509,7 +509,7 @@ def test_send_handshake_returns_server_version(socket_pair):
         t.start()
 
         version = client_conn.send_handshake()
-        assert float(version) == PROTOCOL_VERSION
+        assert version == PROTOCOL_VERSION
 
         t.join(timeout=5)
 


### PR DESCRIPTION
The previous tag was in the "standards action required" section of the cbor tags list, even though it was technically unassigned. Nlohmann doesn't forward tags in this range, which is a decision I disagree with but understand. We're more spec conformant by moving to an unassigned tag in the "specification required" range or higher: https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml. I've chosen 91.