### PR TITLE
Add conformance tests for non-basic paths in lists and dicts

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+Add dual-path conformance testing: every conformance test now runs in both "basic" (schema) and "non_basic" (compositional fallback) modes. Add `unique` parameter to list conformance tests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-Add dual-path conformance testing: every conformance test now runs in both "basic" (schema) and "non_basic" (compositional fallback) modes. Add `unique` parameter to list conformance tests.
+`ListConformance` and `DictConformance` now run twice; once with `{"mode": "basic"}`, and once with `{"mode": "non_basic"}`, indicating the element generators should be basic or non-basic respectively.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
 Add dual-path conformance testing: every conformance test now runs in both "basic" (schema) and "non_basic" (compositional fallback) modes. Add `unique` parameter to list conformance tests.

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -127,7 +127,7 @@ def _integer_params_strategy(
 
 class ConformanceTest(ABC):
     default_test_cases: int = 50
-    modes: list[str] | None = None
+    modes: ClassVar[list[str] | None] = None
     registered_tests: ClassVar[set[type["ConformanceTest"]]] = set()
 
     def __init_subclass__(cls) -> None:
@@ -710,7 +710,7 @@ def run_conformance_tests(
     }
 
     for test in tests:
-        for mode in test.modes if test.modes is not None else [None]:
+        for mode in test.modes if test.modes is not None else [None]:  # type: ignore
             suffix = f"[{mode}]" if mode is not None else ""
             with subtests.test(msg=f"{type(test).__name__}{suffix}"):
 

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -532,10 +532,21 @@ class ListConformance(ConformanceTest):
                 else None
             )
 
+            integer_params = draw(_integer_params_strategy(min_value, max_value))
+            unique = draw(st.booleans())
+
+            if unique:
+                lo = integer_params["min_value"]
+                hi = integer_params["max_value"]
+                effective_max_size = max_size if max_size is not None else min_size
+                if lo is not None and hi is not None:
+                    assume(hi - lo + 1 >= effective_max_size)
+
             return {
                 "min_size": min_size,
                 "max_size": max_size,
-                **draw(_integer_params_strategy(min_value, max_value)),
+                "unique": unique,
+                **integer_params,
             }
 
         return strategy()
@@ -552,6 +563,9 @@ class ListConformance(ConformanceTest):
             assert size >= params["min_size"]
             if params["max_size"] is not None:
                 assert size <= params["max_size"]
+
+            if params["unique"]:
+                assert metrics["all_unique"]
 
             if size > 0:
                 if params["min_value"] is not None:
@@ -690,20 +704,22 @@ def run_conformance_tests(
     }
 
     for test in tests:
-        with subtests.test(msg=type(test).__name__):
-            # When conformance tests fail, they take ages to shrink and tend to
-            # hit the 5 minute cap. Get ahead of that by disabling shrinking.
-            @Settings(
-                parent=settings,
-                max_examples=5,
-                deadline=None,
-                phases=set(Phase) - {Phase.shrink},
-            )
-            @given(test.params_strategy())
-            def run_test(params: dict[str, Any]) -> None:
-                test.run(params)
+        for mode in ["basic", "non_basic"]:
+            with subtests.test(msg=f"{type(test).__name__}[{mode}]"):
+                # When conformance tests fail, they take ages to shrink and tend to
+                # hit the 5 minute cap. Get ahead of that by disabling shrinking.
+                @Settings(
+                    parent=settings,
+                    max_examples=5,
+                    deadline=None,
+                    phases=set(Phase) - {Phase.shrink},
+                )
+                @given(test.params_strategy())
+                def run_test(params: dict[str, Any], *, _mode: str = mode) -> None:
+                    params["mode"] = _mode
+                    test.run(params)
 
-            run_test()
+                run_test()
 
     # gives callers visibility into skipped tests in pytest output (and a reminder to
     # implement them).

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -127,6 +127,7 @@ def _integer_params_strategy(
 
 class ConformanceTest(ABC):
     default_test_cases: int = 50
+    dual_path: bool = False
     registered_tests: ClassVar[set[type["ConformanceTest"]]] = set()
 
     def __init_subclass__(cls) -> None:
@@ -504,6 +505,8 @@ class BinaryConformance(ConformanceTest):
 
 
 class ListConformance(ConformanceTest):
+    dual_path = True
+
     def __init__(
         self,
         binary_path: str | Path,
@@ -603,6 +606,8 @@ class SampledFromConformance(ConformanceTest):
 
 
 class DictConformance(ConformanceTest):
+    dual_path = True
+
     def __init__(
         self,
         binary_path: str | Path,
@@ -705,10 +710,25 @@ def run_conformance_tests(
     }
 
     for test in tests:
-        for mode in ["basic", "non_basic"]:
-            with subtests.test(msg=f"{type(test).__name__}[{mode}]"):
-                # When conformance tests fail, they take ages to shrink and tend to
-                # hit the 5 minute cap. Get ahead of that by disabling shrinking.
+        if test.dual_path:
+            for mode in ["basic", "non_basic"]:
+                with subtests.test(msg=f"{type(test).__name__}[{mode}]"):
+
+                    @Settings(
+                        parent=settings,
+                        max_examples=5,
+                        deadline=None,
+                        phases=set(Phase) - {Phase.shrink},
+                    )
+                    @given(test.params_strategy())
+                    def run_test(params: dict[str, Any], *, _mode: str = mode) -> None:
+                        params["mode"] = _mode
+                        test.run(params)
+
+                    run_test()
+        else:
+            with subtests.test(msg=type(test).__name__):
+
                 @Settings(
                     parent=settings,
                     max_examples=5,
@@ -717,7 +737,6 @@ def run_conformance_tests(
                 )
                 @given(test.params_strategy())
                 def run_test(params: dict[str, Any]) -> None:
-                    params["mode"] = mode
                     test.run(params)
 
                 run_test()

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -505,7 +505,7 @@ class BinaryConformance(ConformanceTest):
 
 
 class ListConformance(ConformanceTest):
-    modes = ["basic", "non_basic"]
+    modes: ClassVar[list[str]] = ["basic", "non_basic"]
 
     def __init__(
         self,
@@ -606,7 +606,7 @@ class SampledFromConformance(ConformanceTest):
 
 
 class DictConformance(ConformanceTest):
-    modes = ["basic", "non_basic"]
+    modes: ClassVar[list[str]] = ["basic", "non_basic"]
 
     def __init__(
         self,

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -559,19 +559,20 @@ class ListConformance(ConformanceTest):
         for metrics in metrics_list:
             if currently_in_test_context():
                 note(f"metrics: {metrics}")
-            size = metrics["size"]
+            elements = metrics["elements"]
+            size = len(elements)
             assert size >= params["min_size"]
             if params["max_size"] is not None:
                 assert size <= params["max_size"]
 
-            if params["unique"]:
-                assert metrics["all_unique"]
-
             if size > 0:
                 if params["min_value"] is not None:
-                    assert metrics["min_element"] >= params["min_value"]
+                    assert min(elements) >= params["min_value"]
                 if params["max_value"] is not None:
-                    assert metrics["max_element"] <= params["max_value"]
+                    assert max(elements) <= params["max_value"]
+
+            if params.get("unique"):
+                assert len(set(elements)) == size
 
 
 class SampledFromConformance(ConformanceTest):

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import unicodedata
 from abc import ABC, abstractmethod
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from encodings.aliases import aliases
 from pathlib import Path
 from typing import Any, ClassVar
@@ -714,18 +714,21 @@ def run_conformance_tests(
             for mode in ["basic", "non_basic"]:
                 with subtests.test(msg=f"{type(test).__name__}[{mode}]"):
 
-                    @Settings(
-                        parent=settings,
-                        max_examples=5,
-                        deadline=None,
-                        phases=set(Phase) - {Phase.shrink},
-                    )
-                    @given(test.params_strategy())
-                    def run_test(params: dict[str, Any], *, _mode: str = mode) -> None:
-                        params["mode"] = _mode
-                        test.run(params)
+                    def make_run_test(bound_mode: str) -> Callable[[], None]:
+                        @Settings(
+                            parent=settings,
+                            max_examples=5,
+                            deadline=None,
+                            phases=set(Phase) - {Phase.shrink},
+                        )
+                        @given(params=test.params_strategy())
+                        def run_test(params: dict[str, Any]) -> None:
+                            params["mode"] = bound_mode
+                            test.run(params)
 
-                    run_test()
+                        return run_test
+
+                    make_run_test(mode)()
         else:
             with subtests.test(msg=type(test).__name__):
 

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 import unicodedata
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Collection
+from collections.abc import Collection
 from encodings.aliases import aliases
 from pathlib import Path
 from typing import Any, ClassVar
@@ -127,7 +127,7 @@ def _integer_params_strategy(
 
 class ConformanceTest(ABC):
     default_test_cases: int = 50
-    dual_path: bool = False
+    modes: list[str] | None = None
     registered_tests: ClassVar[set[type["ConformanceTest"]]] = set()
 
     def __init_subclass__(cls) -> None:
@@ -505,7 +505,7 @@ class BinaryConformance(ConformanceTest):
 
 
 class ListConformance(ConformanceTest):
-    dual_path = True
+    modes = ["basic", "non_basic"]
 
     def __init__(
         self,
@@ -606,7 +606,7 @@ class SampledFromConformance(ConformanceTest):
 
 
 class DictConformance(ConformanceTest):
-    dual_path = True
+    modes = ["basic", "non_basic"]
 
     def __init__(
         self,
@@ -710,27 +710,9 @@ def run_conformance_tests(
     }
 
     for test in tests:
-        if test.dual_path:
-            for mode in ["basic", "non_basic"]:
-                with subtests.test(msg=f"{type(test).__name__}[{mode}]"):
-
-                    def make_run_test(bound_mode: str) -> Callable[[], None]:
-                        @Settings(
-                            parent=settings,
-                            max_examples=5,
-                            deadline=None,
-                            phases=set(Phase) - {Phase.shrink},
-                        )
-                        @given(params=test.params_strategy())
-                        def run_test(params: dict[str, Any]) -> None:
-                            params["mode"] = bound_mode
-                            test.run(params)
-
-                        return run_test
-
-                    make_run_test(mode)()
-        else:
-            with subtests.test(msg=type(test).__name__):
+        for mode in test.modes if test.modes is not None else [None]:
+            suffix = f"[{mode}]" if mode is not None else ""
+            with subtests.test(msg=f"{type(test).__name__}{suffix}"):
 
                 @Settings(
                     parent=settings,
@@ -740,6 +722,8 @@ def run_conformance_tests(
                 )
                 @given(test.params_strategy())
                 def run_test(params: dict[str, Any]) -> None:
+                    if mode is not None:
+                        params["mode"] = mode
                     test.run(params)
 
                 run_test()

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -571,7 +571,7 @@ class ListConformance(ConformanceTest):
                 if params["max_value"] is not None:
                     assert max(elements) <= params["max_value"]
 
-            if params.get("unique"):
+            if params["unique"]:
                 assert len(set(elements)) == size
 
 

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -715,8 +715,8 @@ def run_conformance_tests(
                     phases=set(Phase) - {Phase.shrink},
                 )
                 @given(test.params_strategy())
-                def run_test(params: dict[str, Any], *, _mode: str = mode) -> None:
-                    params["mode"] = _mode
+                def run_test(params: dict[str, Any]) -> None:
+                    params["mode"] = mode
                     test.run(params)
 
                 run_test()

--- a/tests/conformance/tests/list.py
+++ b/tests/conformance/tests/list.py
@@ -23,10 +23,7 @@ def main():
     @given(st.lists(elem_strategy, **list_kwargs))
     def run(value):
         metrics = {
-            "size": len(value),
-            "all_unique": len(value) == len(set(value)),
-            "min_element": min(value) if value else None,
-            "max_element": max(value) if value else None,
+            "elements": value,
         }
         with open(metrics_file, "a") as f:
             f.write(json.dumps(metrics) + "\n")

--- a/tests/conformance/tests/list.py
+++ b/tests/conformance/tests/list.py
@@ -11,7 +11,7 @@ def main():
     metrics_file = os.environ["CONFORMANCE_METRICS_FILE"]
     test_cases = int(os.environ["CONFORMANCE_TEST_CASES"])
 
-    list_kwargs = {"min_size": params["min_size"]}
+    list_kwargs = {"min_size": params["min_size"], "unique": params["unique"]}
     if params["max_size"] is not None:
         list_kwargs["max_size"] = params["max_size"]
 
@@ -24,6 +24,7 @@ def main():
     def run(value):
         metrics = {
             "size": len(value),
+            "all_unique": len(value) == len(set(value)),
             "min_element": min(value) if value else None,
             "max_element": max(value) if value else None,
         }


### PR DESCRIPTION
This would have caught https://github.com/hegeldev/hegel-rust/issues/179.

<details><summary>Claude-written description</summary>

Add dual-path conformance testing so every conformance test runs twice — once with `mode = "basic"` (schema path) and once with `mode = "non_basic"` (compositional fallback path). The mode is injected into the params dict before each test run, using a default-argument pattern to avoid closure-over-loop-variable issues.

Also add a `unique` parameter to `ListConformance`:
- `params_strategy()` now draws a `unique: bool` and uses `assume()` to reject invalid combinations where the integer range is too small for unique lists
- `validate()` asserts `metrics["all_unique"]` when `unique` is true

</details>
