### PR TITLE
Backend support for providing a single test case mode

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds a `one_shot` option to the `run_test` protocol command. When set,
+the server runs exactly one test case in final mode and returns the result, with no
+shrinking, replay, or other exploration. This is intended for callers that want to
+execute a single property-test pass with full reporting and then exit immediately.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
 This release adds a `one_shot` option to the `run_test` protocol command. When set,
 the server runs exactly one test case in final mode and returns the result, with no
-shrinking, replay, or other exploration. This is intended for callers that want to
-execute a single property-test pass with full reporting and then exit immediately.
+shrinking, replay, or other exploration. This is mostly intended for callers who
+are running workloads in Antithesis, but is potentially useful for anyone who wishes
+to use Hegel for flexible data generation on a system that they don't have a reset
+button for or that exhibits significantly non-deterministic behaviour.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,9 @@
 RELEASE_TYPE: patch
 
-This release adds a `one_shot` top-level protocol command. When sent instead of
-`run_test`, the server immediately hands a single test case to the client in final
-mode and returns the result, with no shrinking, replay, or other exploration. This
-is mostly intended for callers who are running workloads in Antithesis, but is
-potentially useful for anyone who wishes to use Hegel for flexible data generation
-on a system that they don't have a reset button for or that exhibits significantly
-non-deterministic behaviour.
+This release adds a `single_test_case` top-level protocol command. When sent
+instead of `run_test`, the server immediately hands a single test case to the
+client in final mode and returns the result, with no shrinking, replay, or other
+exploration. This is mostly intended for callers who are running workloads in
+Antithesis, but is potentially useful for anyone who wishes to use Hegel for
+flexible data generation on a system that they don't have a reset button for or
+that exhibits significantly non-deterministic behaviour.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,9 @@
 RELEASE_TYPE: patch
 
-This release adds a `one_shot` option to the `run_test` protocol command. When set,
-the server runs exactly one test case in final mode and returns the result, with no
-shrinking, replay, or other exploration. This is mostly intended for callers who
-are running workloads in Antithesis, but is potentially useful for anyone who wishes
-to use Hegel for flexible data generation on a system that they don't have a reset
-button for or that exhibits significantly non-deterministic behaviour.
+This release adds a `one_shot` top-level protocol command. When sent instead of
+`run_test`, the server immediately hands a single test case to the client in final
+mode and returns the result, with no shrinking, replay, or other exploration. This
+is mostly intended for callers who are running workloads in Antithesis, but is
+potentially useful for anyone who wishes to use Hegel for flexible data generation
+on a system that they don't have a reset button for or that exhibits significantly
+non-deterministic behaviour.

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -652,6 +652,10 @@ no shrinking, no replay of interesting examples, and no other exploration.
 Clients that want to execute a single property-test pass and then exit
 immediately should set `one_shot: true`.
 
+If `failure_blob` is also provided, the one-shot run replays the choices from
+the blob instead of generating fresh random data. This is the simplest way to
+reproduce a previously reported failure without any additional exploration.
+
 ## Error Handling
 
 ### The `assume()` Function

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -623,7 +623,7 @@ Followed by a CBOR-encoded payload and a terminator byte (`0x0A`).
 | Command | Direction | Description |
 |---------|-----------|-------------|
 | `run_test` | Client -> Server | Start a property test |
-| `one_shot` | Client -> Server | Run a single test case in final mode |
+| `single_test_case` | Client -> Server | Run a single test case in final mode |
 | `generate` | Client -> Server | Generate a value from a schema |
 | `start_span` | Client -> Server | Begin a span group |
 | `stop_span` | Client -> Server | End a span group |
@@ -644,17 +644,17 @@ Followed by a CBOR-encoded payload and a terminator byte (`0x0A`).
 
 - **Request ID matching**: Always verify reply ID matches request ID.
 
-### One-shot Tests
+### Single Test Case
 
-The `one_shot` command is a top-level protocol command sent on the control stream
-instead of `run_test`. It accepts a `stream_id` and an optional `seed`. The
-server immediately hands a single test case to the client on the provided stream
-(with `is_final: true`), reports the result via `test_done`, and performs no
-shrinking, no replay, and no other exploration.
+The `single_test_case` command is a top-level protocol command sent on the
+control stream instead of `run_test`. It accepts a `stream_id` and an optional
+`seed`. The server immediately hands a single test case to the client on the
+provided stream (with `is_final: true`), reports the result via `test_done`, and
+performs no shrinking, no replay, and no other exploration.
 
-The `test_done` event from a one-shot run always reports an empty `failure_blobs`
-list — one-shot blobs use a different internal entropy budget and cannot be
-replayed via `run_test` with `failure_blob`.
+The `test_done` event from a `single_test_case` run always reports an empty
+`failure_blobs` list — the internal entropy budget is different from normal runs
+and the blobs cannot be replayed via `run_test` with `failure_blob`.
 
 ## Error Handling
 

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -654,7 +654,9 @@ immediately should set `one_shot: true`.
 
 `one_shot` cannot be combined with `failure_blob`: the internal entropy budget
 used by a one-shot run is different from the one used for normal runs, so
-failure blobs produced by the two modes are not interchangeable.
+failure blobs produced by the two modes are not interchangeable. For the same
+reason, the `test_done` event from a one-shot run always reports an empty
+`failure_blobs` list even when the test fails — the blob could not be replayed.
 
 ## Error Handling
 

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -623,6 +623,7 @@ Followed by a CBOR-encoded payload and a terminator byte (`0x0A`).
 | Command | Direction | Description |
 |---------|-----------|-------------|
 | `run_test` | Client -> Server | Start a property test |
+| `one_shot` | Client -> Server | Run a single test case in final mode |
 | `generate` | Client -> Server | Generate a value from a schema |
 | `start_span` | Client -> Server | Begin a span group |
 | `stop_span` | Client -> Server | End a span group |
@@ -645,18 +646,15 @@ Followed by a CBOR-encoded payload and a terminator byte (`0x0A`).
 
 ### One-shot Tests
 
-The `run_test` command accepts an optional `one_shot` boolean field. When `true`,
-the server runs exactly one test case in final mode (i.e. the `test_case` event
-is sent with `is_final: true`), reports the result via `test_done`, and performs
-no shrinking, no replay of interesting examples, and no other exploration.
-Clients that want to execute a single property-test pass and then exit
-immediately should set `one_shot: true`.
+The `one_shot` command is a top-level protocol command sent on the control stream
+instead of `run_test`. It accepts a `stream_id` and an optional `seed`. The
+server immediately hands a single test case to the client on the provided stream
+(with `is_final: true`), reports the result via `test_done`, and performs no
+shrinking, no replay, and no other exploration.
 
-`one_shot` cannot be combined with `failure_blob`: the internal entropy budget
-used by a one-shot run is different from the one used for normal runs, so
-failure blobs produced by the two modes are not interchangeable. For the same
-reason, the `test_done` event from a one-shot run always reports an empty
-`failure_blobs` list even when the test fails — the blob could not be replayed.
+The `test_done` event from a one-shot run always reports an empty `failure_blobs`
+list — one-shot blobs use a different internal entropy budget and cannot be
+replayed via `run_test` with `failure_blob`.
 
 ## Error Handling
 

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -643,6 +643,15 @@ Followed by a CBOR-encoded payload and a terminator byte (`0x0A`).
 
 - **Request ID matching**: Always verify reply ID matches request ID.
 
+### One-shot Tests
+
+The `run_test` command accepts an optional `one_shot` boolean field. When `true`,
+the server runs exactly one test case in final mode (i.e. the `test_case` event
+is sent with `is_final: true`), reports the result via `test_done`, and performs
+no shrinking, no replay of interesting examples, and no other exploration.
+Clients that want to execute a single property-test pass and then exit
+immediately should set `one_shot: true`.
+
 ## Error Handling
 
 ### The `assume()` Function

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -652,9 +652,9 @@ no shrinking, no replay of interesting examples, and no other exploration.
 Clients that want to execute a single property-test pass and then exit
 immediately should set `one_shot: true`.
 
-If `failure_blob` is also provided, the one-shot run replays the choices from
-the blob instead of generating fresh random data. This is the simplest way to
-reproduce a previously reported failure without any additional exploration.
+`one_shot` cannot be combined with `failure_blob`: the internal entropy budget
+used by a one-shot run is different from the one used for normal runs, so
+failure blobs produced by the two modes are not interchangeable.
 
 ## Error Handling
 

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -327,7 +327,20 @@ def run_server_on_connection(connection: Connection) -> None:
                             ),
                             derandomize=message.get("derandomize", False),
                             database=message.get("database", not_set),
-                            one_shot=message.get("one_shot", False),
+                        ),
+                    )
+                    connection.control_stream.write_reply(packet.message_id, True)
+                elif command == "one_shot":
+                    stream = connection.register_client_stream(
+                        message["stream_id"], role="One-shot stream"
+                    )
+
+                    pending_futures.append(
+                        thread_pool.submit(
+                            _one_shot,
+                            connection,
+                            stream,
+                            seed=message.get("seed"),
                         ),
                     )
                     connection.control_stream.write_reply(packet.message_id, True)
@@ -347,6 +360,62 @@ def run_server_on_connection(connection: Connection) -> None:
             f.cancel()
 
 
+def _one_shot(
+    connection: Connection,
+    stream: Stream,
+    *,
+    seed: int | None,
+) -> dict[str, Any]:
+    """Run a single one-shot test case.
+
+    Immediately hands a single test case to the client on the provided stream,
+    with is_final=True. No shrinking, no replay, no exploration.
+    """
+    try:
+        seed = random.getrandbits(128) if seed is None else seed
+
+        state = HegelState(connection, stream, is_final=True)
+        runner = ConjectureRunner(
+            state.test_function,
+            settings=settings(
+                deadline=None,
+                max_examples=1,
+                backend=(
+                    "hypothesis-urandom"
+                    if os.environ.get("ANTITHESIS_OUTPUT_DIR")
+                    else "hypothesis"
+                ),
+            ),
+            random=Random(seed),
+            database_key=None,
+        )
+        data = runner.new_conjecture_data(
+            [], observer=DataObserver(), max_choices=2**64
+        )
+        data.max_length = 2**64
+        with contextlib.suppress(StopTest):
+            state.test_function(data)
+        data.freeze()
+
+        is_interesting = data.status is Status.INTERESTING
+        is_valid = data.status is Status.VALID
+        is_invalid = data.status is Status.INVALID
+        result: dict[str, Any] = {
+            "passed": not is_interesting,
+            "test_cases": 1,
+            "valid_test_cases": int(is_valid),
+            "invalid_test_cases": int(is_invalid),
+            "interesting_test_cases": int(is_interesting),
+            "seed": str(seed),
+            "failure_blobs": [],
+        }
+        stream.send_request({"event": "test_done", "results": result}).get()
+        return result
+    except Exception:
+        traceback.print_exc()
+        raise
+
+
 def _run_test(
     connection: Connection,
     stream: Stream,
@@ -358,7 +427,6 @@ def _run_test(
     suppress_health_check: list[str] | None,
     derandomize: bool,
     database: str | UniqueIdentifier | None,
-    one_shot: bool = False,
 ) -> dict[str, Any]:
     """Run a single test using ConjectureRunner.
 
@@ -370,19 +438,6 @@ def _run_test(
     - failure: optional dict with failure details
     """
     try:
-        if one_shot and failure_blob is not None:
-            result: dict[str, Any] = {
-                "passed": False,
-                "test_cases": 0,
-                "valid_test_cases": 0,
-                "invalid_test_cases": 0,
-                "interesting_test_cases": 0,
-                "seed": str(seed),
-                "error": "Cannot combine one_shot with failure_blob.",
-            }
-            stream.send_request({"event": "test_done", "results": result}).get()
-            return result
-
         # seed takes precendence over derandomize, like Hypothesis
         if derandomize and seed is None:
             seed = (
@@ -398,7 +453,7 @@ def _run_test(
                 suppress.append(check)
             else:
                 valid = list(SUPPORTED_HEALTH_CHECKS.keys())
-                result = {
+                result: dict[str, Any] = {
                     "passed": False,
                     "test_cases": 0,
                     "valid_test_cases": 0,
@@ -431,7 +486,7 @@ def _run_test(
             **({} if database is not_set else {"database": database}),
         }
 
-        state = HegelState(connection, stream, is_final=one_shot)
+        state = HegelState(connection, stream)
         runner = ConjectureRunner(
             state.test_function,
             settings=settings(**settings_kwargs),  # type: ignore
@@ -439,35 +494,7 @@ def _run_test(
             database_key=database_key,
         )
         try:
-            if one_shot:
-                data = runner.new_conjecture_data(
-                    [], observer=DataObserver(), max_choices=2**64
-                )
-                # Lift the default per-test-case entropy budget so one-shot
-                # tests can generate as much data as they like.
-                data.max_length = 2**64
-                with contextlib.suppress(StopTest):
-                    state.test_function(data)
-                data.freeze()
-
-                is_interesting = data.status is Status.INTERESTING
-                is_valid = data.status is Status.VALID
-                is_invalid = data.status is Status.INVALID
-                # No failure_blobs: one-shot blobs can't be replayed (the server
-                # rejects one_shot + failure_blob), so reporting them would be
-                # misleading.
-                result = {
-                    "passed": not is_interesting,
-                    "test_cases": 1,
-                    "valid_test_cases": int(is_valid),
-                    "invalid_test_cases": int(is_invalid),
-                    "interesting_test_cases": int(is_interesting),
-                    "seed": str(seed),
-                    "failure_blobs": [],
-                }
-                stream.send_request({"event": "test_done", "results": result}).get()
-                return result
-            elif failure_blob is not None:
+            if failure_blob is not None:
                 choices = decode_failure(failure_blob)
                 data = ConjectureData.for_choices(choices)
                 with contextlib.suppress(StopTest):

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -22,6 +22,11 @@ from hypothesis.errors import (
 )
 from hypothesis.internal.conjecture.data import ConjectureData, DataObserver, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, ExitReason
+from hypothesis.internal.conjecture.providers import (
+    HypothesisProvider,
+    URandom,
+    URandomProvider,
+)
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.conjecture.utils import calc_label_from_name, many
 
@@ -373,41 +378,33 @@ def _single_test_case(
     with is_final=True. No shrinking, no replay, no exploration.
     """
     try:
-        seed = random.getrandbits(128) if seed is None else seed
+        antithesis = os.environ.get("ANTITHESIS_OUTPUT_DIR")
+        if antithesis:
+            rng: Random = URandom()
+        else:
+            seed = random.getrandbits(128) if seed is None else seed
+            rng = Random(seed)
 
-        state = HegelState(connection, stream, is_final=True)
-        runner = ConjectureRunner(
-            state.test_function,
-            settings=settings(
-                deadline=None,
-                max_examples=1,
-                backend=(
-                    "hypothesis-urandom"
-                    if os.environ.get("ANTITHESIS_OUTPUT_DIR")
-                    else "hypothesis"
-                ),
-            ),
-            random=Random(seed),
-            database_key=None,
-        )
-        data = runner.new_conjecture_data(
-            [], observer=DataObserver(), max_choices=2**64
+        data = ConjectureData(
+            random=rng,
+            observer=DataObserver(),
+            provider=URandomProvider if antithesis else HypothesisProvider,
+            max_choices=2**64,
         )
         data.max_length = 2**64
+
+        state = HegelState(connection, stream, is_final=True)
         with contextlib.suppress(StopTest):
             state.test_function(data)
         data.freeze()
 
-        is_interesting = data.status is Status.INTERESTING
-        is_valid = data.status is Status.VALID
-        is_invalid = data.status is Status.INVALID
         result: dict[str, Any] = {
-            "passed": not is_interesting,
+            "passed": data.status is not Status.INTERESTING,
             "test_cases": 1,
-            "valid_test_cases": int(is_valid),
-            "invalid_test_cases": int(is_invalid),
-            "interesting_test_cases": int(is_interesting),
-            "seed": str(seed),
+            "valid_test_cases": int(data.status is Status.VALID),
+            "invalid_test_cases": int(data.status is Status.INVALID),
+            "interesting_test_cases": int(data.status is Status.INTERESTING),
+            "seed": str(seed) if not antithesis else None,
             "failure_blobs": [],
         }
         stream.send_request({"event": "test_done", "results": result}).get()

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -443,6 +443,9 @@ def _run_test(
                 data = runner.new_conjecture_data(
                     [], observer=DataObserver(), max_choices=2**64
                 )
+                # Lift the default per-test-case entropy budget so one-shot
+                # tests can generate as much data as they like.
+                data.max_length = 2**64
                 with contextlib.suppress(StopTest):
                     state.test_function(data)
                 data.freeze()

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -453,6 +453,9 @@ def _run_test(
                 is_interesting = data.status is Status.INTERESTING
                 is_valid = data.status is Status.VALID
                 is_invalid = data.status is Status.INVALID
+                # No failure_blobs: one-shot blobs can't be replayed (the server
+                # rejects one_shot + failure_blob), so reporting them would be
+                # misleading.
                 result = {
                     "passed": not is_interesting,
                     "test_cases": 1,
@@ -460,9 +463,7 @@ def _run_test(
                     "invalid_test_cases": int(is_invalid),
                     "interesting_test_cases": int(is_interesting),
                     "seed": str(seed),
-                    "failure_blobs": (
-                        [encode_failure(data.choices)] if is_interesting else []
-                    ),
+                    "failure_blobs": [],
                 }
                 stream.send_request({"event": "test_done", "results": result}).get()
                 return result

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -370,6 +370,19 @@ def _run_test(
     - failure: optional dict with failure details
     """
     try:
+        if one_shot and failure_blob is not None:
+            result: dict[str, Any] = {
+                "passed": False,
+                "test_cases": 0,
+                "valid_test_cases": 0,
+                "invalid_test_cases": 0,
+                "interesting_test_cases": 0,
+                "seed": str(seed),
+                "error": "Cannot combine one_shot with failure_blob.",
+            }
+            stream.send_request({"event": "test_done", "results": result}).get()
+            return result
+
         # seed takes precendence over derandomize, like Hypothesis
         if derandomize and seed is None:
             seed = (
@@ -385,7 +398,7 @@ def _run_test(
                 suppress.append(check)
             else:
                 valid = list(SUPPORTED_HEALTH_CHECKS.keys())
-                result: dict[str, Any] = {
+                result = {
                     "passed": False,
                     "test_cases": 0,
                     "valid_test_cases": 0,
@@ -427,11 +440,9 @@ def _run_test(
         )
         try:
             if one_shot:
-                if failure_blob is not None:
-                    choices = decode_failure(failure_blob)
-                    data = ConjectureData.for_choices(choices)
-                else:
-                    data = runner.new_conjecture_data([], observer=DataObserver())
+                data = runner.new_conjecture_data(
+                    [], observer=DataObserver(), max_choices=2**64
+                )
                 with contextlib.suppress(StopTest):
                     state.test_function(data)
                 data.freeze()

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -427,7 +427,11 @@ def _run_test(
         )
         try:
             if one_shot:
-                data = runner.new_conjecture_data([], observer=DataObserver())
+                if failure_blob is not None:
+                    choices = decode_failure(failure_blob)
+                    data = ConjectureData.for_choices(choices)
+                else:
+                    data = runner.new_conjecture_data([], observer=DataObserver())
                 with contextlib.suppress(StopTest):
                     state.test_function(data)
                 data.freeze()

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -20,7 +20,7 @@ from hypothesis.errors import (
     StopTest,
     UnsatisfiedAssumption,
 )
-from hypothesis.internal.conjecture.data import ConjectureData, Status
+from hypothesis.internal.conjecture.data import ConjectureData, DataObserver, Status
 from hypothesis.internal.conjecture.engine import ConjectureRunner, ExitReason
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.conjecture.utils import calc_label_from_name, many
@@ -327,6 +327,7 @@ def run_server_on_connection(connection: Connection) -> None:
                             ),
                             derandomize=message.get("derandomize", False),
                             database=message.get("database", not_set),
+                            one_shot=message.get("one_shot", False),
                         ),
                     )
                     connection.control_stream.write_reply(packet.message_id, True)
@@ -357,6 +358,7 @@ def _run_test(
     suppress_health_check: list[str] | None,
     derandomize: bool,
     database: str | UniqueIdentifier | None,
+    one_shot: bool = False,
 ) -> dict[str, Any]:
     """Run a single test using ConjectureRunner.
 
@@ -416,7 +418,7 @@ def _run_test(
             **({} if database is not_set else {"database": database}),
         }
 
-        state = HegelState(connection, stream, is_final=False)
+        state = HegelState(connection, stream, is_final=one_shot)
         runner = ConjectureRunner(
             state.test_function,
             settings=settings(**settings_kwargs),  # type: ignore
@@ -424,7 +426,29 @@ def _run_test(
             database_key=database_key,
         )
         try:
-            if failure_blob is not None:
+            if one_shot:
+                data = runner.new_conjecture_data([], observer=DataObserver())
+                with contextlib.suppress(StopTest):
+                    state.test_function(data)
+                data.freeze()
+
+                is_interesting = data.status is Status.INTERESTING
+                is_valid = data.status is Status.VALID
+                is_invalid = data.status is Status.INVALID
+                result = {
+                    "passed": not is_interesting,
+                    "test_cases": 1,
+                    "valid_test_cases": int(is_valid),
+                    "invalid_test_cases": int(is_invalid),
+                    "interesting_test_cases": int(is_interesting),
+                    "seed": str(seed),
+                    "failure_blobs": (
+                        [encode_failure(data.choices)] if is_interesting else []
+                    ),
+                }
+                stream.send_request({"event": "test_done", "results": result}).get()
+                return result
+            elif failure_blob is not None:
                 choices = decode_failure(failure_blob)
                 data = ConjectureData.for_choices(choices)
                 with contextlib.suppress(StopTest):

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -330,14 +330,15 @@ def run_server_on_connection(connection: Connection) -> None:
                         ),
                     )
                     connection.control_stream.write_reply(packet.message_id, True)
-                elif command == "one_shot":
+                elif command == "single_test_case":
                     stream = connection.register_client_stream(
-                        message["stream_id"], role="One-shot stream"
+                        message["stream_id"],
+                        role="Single test case stream",
                     )
 
                     pending_futures.append(
                         thread_pool.submit(
-                            _one_shot,
+                            _single_test_case,
                             connection,
                             stream,
                             seed=message.get("seed"),
@@ -360,13 +361,13 @@ def run_server_on_connection(connection: Connection) -> None:
             f.cancel()
 
 
-def _one_shot(
+def _single_test_case(
     connection: Connection,
     stream: Stream,
     *,
     seed: int | None,
 ) -> dict[str, Any]:
-    """Run a single one-shot test case.
+    """Run a single test case.
 
     Immediately hands a single test case to the client on the provided stream,
     with is_final=True. No shrinking, no replay, no exploration.

--- a/tests/client/client.py
+++ b/tests/client/client.py
@@ -51,6 +51,65 @@ class Client:
         self.__lock = threading.Lock()
         self.last_result: dict | None = None
 
+    def one_shot(
+        self,
+        test_fn: Callable[[], None],
+        *,
+        seed: int | None = None,
+    ) -> None:
+        """Run a single one-shot test case."""
+
+        test_stream = self.connection.new_stream()
+
+        message: dict[str, Any] = {
+            "command": "one_shot",
+            "seed": seed,
+            "stream_id": test_stream.stream_id,
+        }
+
+        with self.__lock:
+            self._control.send_request(message)
+
+        result_data = None
+
+        while True:
+            packet = test_stream.read_request()
+            message = cbor2.loads(packet.payload)
+            event = message.get("event")
+
+            if event == "test_case":
+                stream_id = message["stream_id"]
+                is_final = message.get("is_final", False)
+                test_stream.write_reply(packet.message_id, None)
+                test_case_stream = self.connection.connect_stream(stream_id)
+                self._run_test_case(test_case_stream, test_fn, is_final=is_final)
+            elif event == "test_done":
+                test_stream.write_reply(packet.message_id, True)
+                result_data = message["results"]
+                break
+            else:
+                test_stream.write_reply_error(
+                    packet.message_id,
+                    error=f"Unrecognised event {event}",
+                    error_type="InvalidMessage",
+                )
+
+        assert result_data is not None
+        self.last_result = result_data
+
+        if "error" in result_data:
+            raise ValueError(result_data["error"])
+
+        n_interesting = result_data["interesting_test_cases"]
+
+        if n_interesting == 0:
+            return
+
+        # One-shot runs in final mode, so the exception was already raised
+        # during the test_case handling above. This path handles the case
+        # where is_final was set but the exception wasn't propagated.
+        raise ValueError("One-shot test failed but exception was not propagated")
+
     def run_test(
         self,
         test_fn: Callable[[], None],
@@ -62,7 +121,6 @@ class Client:
         database_key: bytes | None = None,
         derandomize: bool = False,
         database: str | None | UniqueIdentifier = not_set,
-        one_shot: bool = False,
     ) -> None:
         """Run a property test."""
 
@@ -76,7 +134,6 @@ class Client:
             "database_key": database_key,
             "derandomize": derandomize,
             "failure_blob": failure_blob,
-            "one_shot": one_shot,
         }
         if database is not not_set:
             message["database"] = database

--- a/tests/client/client.py
+++ b/tests/client/client.py
@@ -62,6 +62,7 @@ class Client:
         database_key: bytes | None = None,
         derandomize: bool = False,
         database: str | None | UniqueIdentifier = not_set,
+        one_shot: bool = False,
     ) -> None:
         """Run a property test."""
 
@@ -75,6 +76,7 @@ class Client:
             "database_key": database_key,
             "derandomize": derandomize,
             "failure_blob": failure_blob,
+            "one_shot": one_shot,
         }
         if database is not not_set:
             message["database"] = database
@@ -93,9 +95,10 @@ class Client:
 
             if event == "test_case":
                 stream_id = message["stream_id"]
+                is_final = message.get("is_final", False)
                 test_stream.write_reply(packet.message_id, None)
                 test_case_stream = self.connection.connect_stream(stream_id)
-                self._run_test_case(test_case_stream, test_fn, is_final=False)
+                self._run_test_case(test_case_stream, test_fn, is_final=is_final)
             elif event == "test_done":
                 test_stream.write_reply(packet.message_id, True)
                 result_data = message["results"]

--- a/tests/client/client.py
+++ b/tests/client/client.py
@@ -51,18 +51,18 @@ class Client:
         self.__lock = threading.Lock()
         self.last_result: dict | None = None
 
-    def one_shot(
+    def single_test_case(
         self,
         test_fn: Callable[[], None],
         *,
         seed: int | None = None,
     ) -> None:
-        """Run a single one-shot test case."""
+        """Run a single test case."""
 
         test_stream = self.connection.new_stream()
 
         message: dict[str, Any] = {
-            "command": "one_shot",
+            "command": "single_test_case",
             "seed": seed,
             "stream_id": test_stream.stream_id,
         }
@@ -105,10 +105,10 @@ class Client:
         if n_interesting == 0:
             return
 
-        # One-shot runs in final mode, so the exception was already raised
-        # during the test_case handling above. This path handles the case
-        # where is_final was set but the exception wasn't propagated.
-        raise ValueError("One-shot test failed but exception was not propagated")
+        # single_test_case runs in final mode, so the exception was already
+        # raised during the test_case handling above. This path handles the
+        # case where is_final was set but the exception wasn't propagated.
+        raise ValueError("single_test_case failed but exception was not propagated")
 
     def run_test(
         self,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1011,84 +1011,14 @@ def test_one_shot_with_seed_is_deterministic(client):
     assert seen[0] == seen[1]
 
 
-def test_one_shot_with_failure_blob_replays_once(client):
-    """one_shot with a failure_blob replays the blob exactly once in final mode."""
+def test_one_shot_with_failure_blob_is_error(client):
+    """Passing both one_shot and failure_blob is rejected."""
 
     def test():
-        assert (
-            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
-            <= 10
-        )
+        generate_from_schema({"type": "integer"})
 
-    with pytest.raises(AssertionError):
-        client.run_test(test, test_cases=100)
-
-    blob = client.last_result["failure_blobs"][0]
-
-    call_count = [0]
-
-    def replay():
-        call_count[0] += 1
-        assert (
-            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
-            <= 10
-        )
-
-    with pytest.raises(AssertionError):
-        client.run_test(replay, one_shot=True, failure_blob=blob)
-
-    assert call_count[0] == 1
-
-
-def test_one_shot_with_failure_blob_that_no_longer_fails(client):
-    """one_shot with a blob that no longer reproduces still runs exactly once."""
-
-    def failing_test():
-        assert (
-            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
-            <= 10
-        )
-
-    with pytest.raises(AssertionError):
-        client.run_test(failing_test, test_cases=100)
-
-    blob = client.last_result["failure_blobs"][0]
-
-    call_count = [0]
-
-    def passing_test():
-        call_count[0] += 1
-        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
-
-    with pytest.raises(AssertionError, match="failure blob did not reproduce"):
-        client.run_test(passing_test, one_shot=True, failure_blob=blob)
-
-    assert call_count[0] == 1
-
-
-def test_one_shot_with_failure_blob_uses_blob_choices(client):
-    """one_shot with a failure_blob replays the exact choices from the blob."""
-    captured = []
-
-    def test():
-        captured.append(
-            generate_from_schema(
-                {"type": "integer", "min_value": 0, "max_value": 10**9}
-            )
-        )
-        assert captured[-1] <= 10
-
-    with pytest.raises(AssertionError):
-        client.run_test(test, test_cases=100)
-
-    blob = client.last_result["failure_blobs"][0]
-    failing_value = captured[-1]
-    captured.clear()
-
-    with pytest.raises(AssertionError):
-        client.run_test(test, one_shot=True, failure_blob=blob)
-
-    assert captured == [failing_value]
+    with pytest.raises(ValueError, match="one_shot.*failure_blob"):
+        client.run_test(test, one_shot=True, failure_blob=b"\x00\x00\x00\x00")
 
 
 def test_one_shot_generation_works(client):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -918,14 +918,14 @@ def test_server_run_metrics_multiple_failures(client, monkeypatch, tmp_path):
     assert result["interesting_test_cases"] > 1
 
 
-def test_one_shot_runs_single_passing_case(client):
+def test_single_test_case_runs_single_passing_case(client):
     call_count = [0]
 
     def test():
         call_count[0] += 1
         generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
 
-    client.one_shot(test)
+    client.single_test_case(test)
 
     assert call_count[0] == 1
     assert client.last_result["test_cases"] == 1
@@ -934,8 +934,8 @@ def test_one_shot_runs_single_passing_case(client):
     assert client.last_result["passed"] is True
 
 
-def test_one_shot_is_final(client):
-    """A one-shot test case runs in is_final=True mode."""
+def test_single_test_case_is_final(client):
+    """A single_test_case runs in is_final=True mode."""
     from tests.client.client import _is_final
 
     seen_is_final = []
@@ -943,15 +943,15 @@ def test_one_shot_is_final(client):
     def test():
         seen_is_final.append(_is_final.get())
 
-    client.one_shot(test)
+    client.single_test_case(test)
     assert seen_is_final == [True]
 
 
-def test_one_shot_invalid_assume(client):
+def test_single_test_case_invalid_assume(client):
     def test():
         assume(False)
 
-    client.one_shot(test)
+    client.single_test_case(test)
 
     assert client.last_result["test_cases"] == 1
     assert client.last_result["invalid_test_cases"] == 1
@@ -960,7 +960,7 @@ def test_one_shot_invalid_assume(client):
     assert client.last_result["passed"] is True
 
 
-def test_one_shot_failing_propagates_exception(client):
+def test_single_test_case_failing_propagates_exception(client):
     call_count = [0]
 
     def test():
@@ -968,13 +968,13 @@ def test_one_shot_failing_propagates_exception(client):
         raise AssertionError("boom")
 
     with pytest.raises(AssertionError, match="boom"):
-        client.one_shot(test)
+        client.single_test_case(test)
 
     assert call_count[0] == 1
 
 
-def test_one_shot_no_shrinking_no_replay(client):
-    """One-shot runs exactly once even when the test fails."""
+def test_single_test_case_no_shrinking_no_replay(client):
+    """single_test_case runs exactly once even when the test fails."""
     call_count = [0]
 
     def test():
@@ -986,12 +986,12 @@ def test_one_shot_no_shrinking_no_replay(client):
         assert x < 0
 
     with pytest.raises(AssertionError):
-        client.one_shot(test)
+        client.single_test_case(test)
 
     assert call_count[0] == 1
 
 
-def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
+def test_single_test_case_with_seed_is_deterministic(client, monkeypatch):
     monkeypatch.delenv("ANTITHESIS_OUTPUT_DIR", raising=False)
     seen = []
 
@@ -1002,8 +1002,8 @@ def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
             )
         )
 
-    client.one_shot(test, seed=12345)
-    client.one_shot(test, seed=12345)
+    client.single_test_case(test, seed=12345)
+    client.single_test_case(test, seed=12345)
 
     assert seen[0] == seen[1]
 
@@ -1012,7 +1012,7 @@ def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
     sys.platform == "win32",
     reason="hypothesis-urandom falls back to the deterministic backend on Windows",
 )
-def test_one_shot_with_seed_is_nondeterministic_under_urandom(
+def test_single_test_case_with_seed_is_nondeterministic_under_urandom(
     client, monkeypatch, tmp_path
 ):
     """Under the hypothesis-urandom backend the seed is ignored, so the same
@@ -1030,25 +1030,25 @@ def test_one_shot_with_seed_is_nondeterministic_under_urandom(
     # Four runs with the same seed. Under urandom, each draw is independent,
     # so the chance of all four producing the same value is ~(10**-9)**3.
     for _ in range(4):
-        client.one_shot(test, seed=12345)
+        client.single_test_case(test, seed=12345)
 
     assert len(seen) > 1
 
 
-def test_one_shot_large_entropy_budget(client):
-    """A one-shot test can generate far more data than Hypothesis's default
+def test_single_test_case_large_entropy_budget(client):
+    """A single_test_case can generate far more data than Hypothesis's default
     per-test-case entropy budget would normally allow."""
 
     def test():
         for _ in range(20_000):
             generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
 
-    client.one_shot(test)
+    client.single_test_case(test)
     assert client.last_result["valid_test_cases"] == 1
 
 
-def test_one_shot_generation_works(client):
-    """A one-shot test can use the full generator surface (lists, spans, etc.)."""
+def test_single_test_case_generation_works(client):
+    """A single_test_case can use the full generator surface (lists, spans, etc.)."""
 
     def test():
         xs = generate_from_schema(
@@ -1063,4 +1063,4 @@ def test_one_shot_generation_works(client):
         for x in xs:
             assert 0 <= x <= 100
 
-    client.one_shot(test)
+    client.single_test_case(test)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1011,6 +1011,18 @@ def test_one_shot_with_seed_is_deterministic(client):
     assert seen[0] == seen[1]
 
 
+def test_one_shot_large_entropy_budget(client):
+    """A one-shot test can generate far more data than Hypothesis's default
+    per-test-case entropy budget would normally allow."""
+
+    def test():
+        for _ in range(20_000):
+            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
+
+    client.run_test(test, one_shot=True)
+    assert client.last_result["valid_test_cases"] == 1
+
+
 def test_one_shot_with_failure_blob_is_error(client):
     """Passing both one_shot and failure_blob is rejected."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1011,6 +1011,86 @@ def test_one_shot_with_seed_is_deterministic(client):
     assert seen[0] == seen[1]
 
 
+def test_one_shot_with_failure_blob_replays_once(client):
+    """one_shot with a failure_blob replays the blob exactly once in final mode."""
+
+    def test():
+        assert (
+            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
+            <= 10
+        )
+
+    with pytest.raises(AssertionError):
+        client.run_test(test, test_cases=100)
+
+    blob = client.last_result["failure_blobs"][0]
+
+    call_count = [0]
+
+    def replay():
+        call_count[0] += 1
+        assert (
+            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
+            <= 10
+        )
+
+    with pytest.raises(AssertionError):
+        client.run_test(replay, one_shot=True, failure_blob=blob)
+
+    assert call_count[0] == 1
+
+
+def test_one_shot_with_failure_blob_that_no_longer_fails(client):
+    """one_shot with a blob that no longer reproduces still runs exactly once."""
+
+    def failing_test():
+        assert (
+            generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
+            <= 10
+        )
+
+    with pytest.raises(AssertionError):
+        client.run_test(failing_test, test_cases=100)
+
+    blob = client.last_result["failure_blobs"][0]
+
+    call_count = [0]
+
+    def passing_test():
+        call_count[0] += 1
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 1000})
+
+    with pytest.raises(AssertionError, match="failure blob did not reproduce"):
+        client.run_test(passing_test, one_shot=True, failure_blob=blob)
+
+    assert call_count[0] == 1
+
+
+def test_one_shot_with_failure_blob_uses_blob_choices(client):
+    """one_shot with a failure_blob replays the exact choices from the blob."""
+    captured = []
+
+    def test():
+        captured.append(
+            generate_from_schema(
+                {"type": "integer", "min_value": 0, "max_value": 10**9}
+            )
+        )
+        assert captured[-1] <= 10
+
+    with pytest.raises(AssertionError):
+        client.run_test(test, test_cases=100)
+
+    blob = client.last_result["failure_blobs"][0]
+    failing_value = captured[-1]
+    captured.clear()
+
+    with pytest.raises(AssertionError):
+        client.run_test(test, one_shot=True, failure_blob=blob)
+
+    assert captured == [failing_value]
+
+
 def test_one_shot_generation_works(client):
     """A one-shot test can use the full generator surface (lists, spans, etc.)."""
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 """Tests for server.py uncovered paths."""
 
 import socket
+import sys
 import time
 from threading import Thread
 
@@ -1007,6 +1008,10 @@ def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
     assert seen[0] == seen[1]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="hypothesis-urandom falls back to the deterministic backend on Windows",
+)
 def test_one_shot_with_seed_is_nondeterministic_under_urandom(
     client, monkeypatch, tmp_path
 ):
@@ -1048,7 +1053,7 @@ def test_one_shot_with_failure_blob_is_error(client):
     def test():
         generate_from_schema({"type": "integer"})
 
-    with pytest.raises(ValueError, match="one_shot.*failure_blob"):
+    with pytest.raises(ValueError, match=r"one_shot.*failure_blob"):
         client.run_test(test, one_shot=True, failure_blob=b"\x00\x00\x00\x00")
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -925,7 +925,7 @@ def test_one_shot_runs_single_passing_case(client):
         call_count[0] += 1
         generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
 
-    client.run_test(test, one_shot=True)
+    client.one_shot(test)
 
     assert call_count[0] == 1
     assert client.last_result["test_cases"] == 1
@@ -943,7 +943,7 @@ def test_one_shot_is_final(client):
     def test():
         seen_is_final.append(_is_final.get())
 
-    client.run_test(test, one_shot=True)
+    client.one_shot(test)
     assert seen_is_final == [True]
 
 
@@ -951,7 +951,7 @@ def test_one_shot_invalid_assume(client):
     def test():
         assume(False)
 
-    client.run_test(test, one_shot=True)
+    client.one_shot(test)
 
     assert client.last_result["test_cases"] == 1
     assert client.last_result["invalid_test_cases"] == 1
@@ -968,7 +968,7 @@ def test_one_shot_failing_propagates_exception(client):
         raise AssertionError("boom")
 
     with pytest.raises(AssertionError, match="boom"):
-        client.run_test(test, one_shot=True)
+        client.one_shot(test)
 
     assert call_count[0] == 1
 
@@ -986,7 +986,7 @@ def test_one_shot_no_shrinking_no_replay(client):
         assert x < 0
 
     with pytest.raises(AssertionError):
-        client.run_test(test, one_shot=True)
+        client.one_shot(test)
 
     assert call_count[0] == 1
 
@@ -1002,8 +1002,8 @@ def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
             )
         )
 
-    client.run_test(test, one_shot=True, seed=12345)
-    client.run_test(test, one_shot=True, seed=12345)
+    client.one_shot(test, seed=12345)
+    client.one_shot(test, seed=12345)
 
     assert seen[0] == seen[1]
 
@@ -1030,7 +1030,7 @@ def test_one_shot_with_seed_is_nondeterministic_under_urandom(
     # Four runs with the same seed. Under urandom, each draw is independent,
     # so the chance of all four producing the same value is ~(10**-9)**3.
     for _ in range(4):
-        client.run_test(test, one_shot=True, seed=12345)
+        client.one_shot(test, seed=12345)
 
     assert len(seen) > 1
 
@@ -1043,18 +1043,8 @@ def test_one_shot_large_entropy_budget(client):
         for _ in range(20_000):
             generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
 
-    client.run_test(test, one_shot=True)
+    client.one_shot(test)
     assert client.last_result["valid_test_cases"] == 1
-
-
-def test_one_shot_with_failure_blob_is_error(client):
-    """Passing both one_shot and failure_blob is rejected."""
-
-    def test():
-        generate_from_schema({"type": "integer"})
-
-    with pytest.raises(ValueError, match=r"one_shot.*failure_blob"):
-        client.run_test(test, one_shot=True, failure_blob=b"\x00\x00\x00\x00")
 
 
 def test_one_shot_generation_works(client):
@@ -1073,4 +1063,4 @@ def test_one_shot_generation_works(client):
         for x in xs:
             assert 0 <= x <= 100
 
-    client.run_test(test, one_shot=True)
+    client.one_shot(test)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,5 +1,6 @@
 """Tests for server.py uncovered paths."""
 
+import os
 import socket
 import time
 from threading import Thread
@@ -915,3 +916,115 @@ def test_server_run_metrics_multiple_failures(client, monkeypatch, tmp_path):
 
     result = json.loads(run_metrics_file.read_text(encoding="utf-8"))
     assert result["interesting_test_cases"] > 1
+
+
+def test_one_shot_runs_single_passing_case(client):
+    call_count = [0]
+
+    def test():
+        call_count[0] += 1
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
+
+    client.run_test(test, one_shot=True)
+
+    assert call_count[0] == 1
+    assert client.last_result["test_cases"] == 1
+    assert client.last_result["valid_test_cases"] == 1
+    assert client.last_result["interesting_test_cases"] == 0
+    assert client.last_result["passed"] is True
+
+
+def test_one_shot_is_final(client):
+    """A one-shot test case runs in is_final=True mode."""
+    from tests.client.client import _is_final
+
+    seen_is_final = []
+
+    def test():
+        seen_is_final.append(_is_final.get())
+
+    client.run_test(test, one_shot=True)
+    assert seen_is_final == [True]
+
+
+def test_one_shot_invalid_assume(client):
+    def test():
+        assume(False)
+
+    client.run_test(test, one_shot=True)
+
+    assert client.last_result["test_cases"] == 1
+    assert client.last_result["invalid_test_cases"] == 1
+    assert client.last_result["valid_test_cases"] == 0
+    assert client.last_result["interesting_test_cases"] == 0
+    assert client.last_result["passed"] is True
+
+
+def test_one_shot_failing_propagates_exception(client):
+    call_count = [0]
+
+    def test():
+        call_count[0] += 1
+        raise AssertionError("boom")
+
+    with pytest.raises(AssertionError, match="boom"):
+        client.run_test(test, one_shot=True)
+
+    assert call_count[0] == 1
+
+
+def test_one_shot_no_shrinking_no_replay(client):
+    """One-shot runs exactly once even when the test fails."""
+    call_count = [0]
+
+    def test():
+        call_count[0] += 1
+        # A test that would normally be shrunk extensively.
+        x = generate_from_schema(
+            {"type": "integer", "min_value": 0, "max_value": 10**9},
+        )
+        assert x < 0
+
+    with pytest.raises(AssertionError):
+        client.run_test(test, one_shot=True)
+
+    assert call_count[0] == 1
+
+
+@pytest.mark.skipif(
+    bool(os.environ.get("ANTITHESIS_OUTPUT_DIR")),
+    reason="hypothesis-urandom backend does not honor the seed",
+)
+def test_one_shot_with_seed_is_deterministic(client):
+    seen = []
+
+    def test():
+        seen.append(
+            generate_from_schema(
+                {"type": "integer", "min_value": 0, "max_value": 10**9},
+            )
+        )
+
+    client.run_test(test, one_shot=True, seed=12345)
+    client.run_test(test, one_shot=True, seed=12345)
+
+    assert seen[0] == seen[1]
+
+
+def test_one_shot_generation_works(client):
+    """A one-shot test can use the full generator surface (lists, spans, etc.)."""
+
+    def test():
+        xs = generate_from_schema(
+            {
+                "type": "list",
+                "elements": {"type": "integer", "min_value": 0, "max_value": 100},
+                "min_size": 1,
+                "max_size": 5,
+            }
+        )
+        assert 1 <= len(xs) <= 5
+        for x in xs:
+            assert 0 <= x <= 100
+
+    client.run_test(test, one_shot=True)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,5 @@
 """Tests for server.py uncovered paths."""
 
-import os
 import socket
 import time
 from threading import Thread
@@ -991,11 +990,8 @@ def test_one_shot_no_shrinking_no_replay(client):
     assert call_count[0] == 1
 
 
-@pytest.mark.skipif(
-    bool(os.environ.get("ANTITHESIS_OUTPUT_DIR")),
-    reason="hypothesis-urandom backend does not honor the seed",
-)
-def test_one_shot_with_seed_is_deterministic(client):
+def test_one_shot_with_seed_is_deterministic(client, monkeypatch):
+    monkeypatch.delenv("ANTITHESIS_OUTPUT_DIR", raising=False)
     seen = []
 
     def test():
@@ -1009,6 +1005,29 @@ def test_one_shot_with_seed_is_deterministic(client):
     client.run_test(test, one_shot=True, seed=12345)
 
     assert seen[0] == seen[1]
+
+
+def test_one_shot_with_seed_is_nondeterministic_under_urandom(
+    client, monkeypatch, tmp_path
+):
+    """Under the hypothesis-urandom backend the seed is ignored, so the same
+    seed produces different values across runs."""
+    monkeypatch.setenv("ANTITHESIS_OUTPUT_DIR", str(tmp_path))
+    seen = set()
+
+    def test():
+        seen.add(
+            generate_from_schema(
+                {"type": "integer", "min_value": 0, "max_value": 10**9},
+            )
+        )
+
+    # Four runs with the same seed. Under urandom, each draw is independent,
+    # so the chance of all four producing the same value is ~(10**-9)**3.
+    for _ in range(4):
+        client.run_test(test, one_shot=True, seed=12345)
+
+    assert len(seen) > 1
 
 
 def test_one_shot_large_entropy_budget(client):


### PR DESCRIPTION
This adds a setting which allows you to run hegel in one-shot mode. That is, you are basically using it entirely for data generation, with no replay, no shrinking, no nothing.

This is useful for writing Antithesis workloads, potentially useful for Bombadil, etc.