### PR TITLE
A variety of concurrency and robustness fixes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+RELEASE_TYPE: patch
+
+This patch fixes several concurrency bugs and improves error handling robustness in the protocol layer.
+
+The server's reader loop no longer crashes when it receives a packet for an unknown or already-closed stream, or a malformed close-stream packet. Instead, it sends an error reply back to the client (for request packets) and continues processing. This means clients that make protocol mistakes will now get a clear ProtocolError response instead of the server silently dying.
+
+Several race conditions in the protocol layer have been fixed. `Connection.close()` and `Stream.close()` now use dedicated locks to ensure their check-and-set guards are atomic, preventing concurrent callers from double-closing. `Connection.close()` holds the writer lock while closing the socket, so no `write_packet` call can be mid-flight when the fd is yanked. `Stream.write_request` protects the message ID increment with a lock so concurrent writers get unique IDs. `Connection.new_stream` allocates stream IDs under the writer lock. `receive_handshake` now sets `_handshake_done` after the handshake reply is sent rather than before.
+
+Bare `assert` statements throughout the protocol and server code have been replaced with explicit error raises (`ProtocolError`, `ValueError`, `ConnectionError`) with descriptive messages. This prevents assertion-removal in optimized Python builds and gives clients and logs meaningful diagnostics.
+
+`StdioTransport.sendall` now converts `ValueError` (from writing to a closed file descriptor) to `OSError`, so the existing error handling in the protocol layer catches it correctly. This fixes the "ValueError: I/O operation on closed file" error that could occur when the client disconnects while the server is still writing.

--- a/src/hegel/__main__.py
+++ b/src/hegel/__main__.py
@@ -32,8 +32,11 @@ class StdioTransport:
         return data
 
     def sendall(self, data):
-        self._writer.write(data)
-        self._writer.flush()
+        try:
+            self._writer.write(data)
+            self._writer.flush()
+        except ValueError as e:
+            raise OSError(str(e)) from e
 
     def settimeout(self, timeout):
         pass  # No timeout support for stdio

--- a/src/hegel/__main__.py
+++ b/src/hegel/__main__.py
@@ -36,6 +36,9 @@ class StdioTransport:
             self._writer.write(data)
             self._writer.flush()
         except ValueError as e:
+            # BufferedWriter raises ValueError("I/O operation on closed file")
+            # but the protocol layer only catches OSError.
+            print(f"StdioTransport write failed: {e}", file=sys.stderr)
             raise OSError(str(e)) from e
 
     def settimeout(self, timeout):

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -14,7 +14,12 @@ from hegel.protocol.packet import (
     read_packet,
     write_packet,
 )
-from hegel.protocol.utils import SHUTDOWN, ConnectionClosedError, StreamId
+from hegel.protocol.utils import (
+    SHUTDOWN,
+    ConnectionClosedError,
+    ProtocolError,
+    StreamId,
+)
 
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
@@ -242,10 +247,14 @@ class Connection:
             write_packet(self.__socket, packet)
 
     def receive_handshake(self):
-        assert not self._handshake_done
+        if self._handshake_done:
+            raise ProtocolError("Handshake already completed")
 
         packet = self.control_stream.read_request()
-        assert packet.payload == HANDSHAKE_STRING
+        if packet.payload != HANDSHAKE_STRING:
+            raise ProtocolError(
+                f"Bad handshake: expected {HANDSHAKE_STRING!r}, got {packet.payload!r}"
+            )
         # we expect the payload to be pure ASCII. ASCII and utf-8 overlap, so passing
         # "ascii" as the encoding is equivalent in the standard case, but gives us a
         # fail-fast error otherwise.
@@ -260,11 +269,14 @@ class Connection:
 
         stream = Stream(connection=self, stream_id=stream_id, role=role)
         with self.__writer_lock:
+            if stream.stream_id in self.streams:
+                raise ProtocolError(f"Stream {stream.stream_id} is already registered")
             self.streams[stream.stream_id] = stream
         return stream
 
     def new_stream(self, *, role: str | None = None) -> "Stream":
-        assert self._handshake_done
+        if not self._handshake_done:
+            raise ProtocolError("Cannot create streams before handshake")
         # server streams get even ids
         with self.__writer_lock:
             stream_id = StreamId(self.__next_stream_id << 1)
@@ -285,8 +297,10 @@ class Connection:
         been created by the client or the server. This method's name explicitly mentions
         the client origin for protocol hygiene, not because it has a fundamental impact.
         """
-        assert self._handshake_done
-        assert stream_id not in self.streams
-        # client streams have odd ids
-        assert stream_id & 1 == 1
+        if not self._handshake_done:
+            raise ProtocolError("Cannot register streams before handshake")
+        if stream_id in self.streams:
+            raise ProtocolError(f"Stream {stream_id} is already registered")
+        if stream_id & 1 != 1:
+            raise ProtocolError(f"Client stream id must be odd, got {stream_id}")
         return self._make_stream(stream_id, role=role)

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -140,9 +140,14 @@ class Connection:
             except Exception:
                 payload_repr = packet.payload
 
-        stream = self.streams[packet.stream_id]
+        stream = self.streams.get(packet.stream_id)
+        stream_label = (
+            str(stream)
+            if stream is not None
+            else f"<unknown stream {packet.stream_id}>"
+        )
         self._debug_print(
-            f"[{self.name or '?'}] {direction} ch={stream}"
+            f"[{self.name or '?'}] {direction} ch={stream_label}"
             f" message_id={packet.message_id}"
             f" {'reply' if packet.is_reply else 'request'}: {payload_repr!r}",
         )
@@ -171,21 +176,63 @@ class Connection:
             while self.running:
                 packet = read_packet(self.__socket)
 
-                stream = self.streams[packet.stream_id]
+                stream = self.streams.get(packet.stream_id)
+                if stream is None:
+                    self._debug_print(
+                        f"Received packet for unknown stream {packet.stream_id}"
+                    )
+                    self._send_error_reply(
+                        packet, f"stream {packet.stream_id} is not registered"
+                    )
+                    continue
+
                 self._debug_packet(packet, direction="RECEIVE")
                 if packet.payload == CLOSE_STREAM_PAYLOAD:
-                    assert packet.message_id == CLOSE_STREAM_MESSAGE_ID
+                    if packet.message_id != CLOSE_STREAM_MESSAGE_ID:
+                        self._debug_print(
+                            f"Ignoring close packet with wrong message_id"
+                            f" {packet.message_id} for {stream}"
+                        )
+                        continue
                     self._debug_print(f"Received close for {stream}")
                     stream.closed = True
                     stream.unprocessed_packets.put(SHUTDOWN)
                 else:
-                    assert not stream.closed
+                    if stream.closed:
+                        self._debug_print(f"Received packet for closed stream {stream}")
+                        self._send_error_reply(packet, f"stream {stream} is closed")
+                        continue
                     stream.unprocessed_packets.put(packet)
-        except (ConnectionClosedError, OSError):
-            pass
+        except (ConnectionClosedError, OSError) as exc:
+            if self.running:
+                print(
+                    f"Reader loop exiting: {type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                )
         finally:
             if self.running:
                 self.close()
+
+    def _send_error_reply(self, packet: Packet, message: str) -> None:
+        """Send an error reply for a request that can't be delivered.
+
+        Only sends a reply for request packets (not replies). If the write
+        fails (e.g. connection is closing), the error is silently ignored.
+        """
+        if packet.is_reply:
+            return
+        try:
+            error_payload = cbor2.dumps({"error": message, "type": "ProtocolError"})
+            self.write_packet(
+                Packet(
+                    stream_id=packet.stream_id,
+                    message_id=packet.message_id,
+                    is_reply=True,
+                    payload=error_payload,
+                )
+            )
+        except (OSError, ConnectionClosedError):
+            pass
 
     def write_packet(self, packet: Packet) -> None:
         with self.__writer_lock:

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -105,6 +105,7 @@ class Connection:
         self.running = True
 
         self.__writer_lock = Lock()
+        self.__close_lock = Lock()
         self.__socket = socket
         self.__next_stream_id = 1
         self._handshake_done = False
@@ -148,16 +149,20 @@ class Connection:
 
     def close(self) -> None:
         """Close the connection and clean up resources."""
-        if not self.running:
-            return
+        with self.__close_lock:
+            if not self.running:
+                return
+            self.running = False
 
-        self.running = False
-        with contextlib.suppress(OSError):
-            self.__socket.shutdown(socket.SHUT_RDWR)
-        with contextlib.suppress(OSError):
-            self.__socket.close()
-
-        for v in self.streams.values():
+        # Hold the writer lock while closing the socket so that no
+        # write_packet call can be in flight when the fd is closed.
+        with self.__writer_lock:
+            with contextlib.suppress(OSError):
+                self.__socket.shutdown(socket.SHUT_RDWR)
+            with contextlib.suppress(OSError):
+                self.__socket.close()
+            streams = list(self.streams.values())
+        for v in streams:
             if not v.closed:
                 v.unprocessed_packets.put(SHUTDOWN)
 
@@ -184,6 +189,8 @@ class Connection:
 
     def write_packet(self, packet: Packet) -> None:
         with self.__writer_lock:
+            if not self.running:
+                raise ConnectionError("Connection closed")
             self._debug_packet(packet, direction="SEND")
             write_packet(self.__socket, packet)
 
@@ -212,8 +219,9 @@ class Connection:
     def new_stream(self, *, role: str | None = None) -> "Stream":
         assert self._handshake_done
         # server streams get even ids
-        stream_id = StreamId(self.__next_stream_id << 1)
-        self.__next_stream_id += 1
+        with self.__writer_lock:
+            stream_id = StreamId(self.__next_stream_id << 1)
+            self.__next_stream_id += 1
         return self._make_stream(stream_id, role=role)
 
     def register_client_stream(

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -197,7 +197,6 @@ class Connection:
     def receive_handshake(self):
         assert not self._handshake_done
 
-        self._handshake_done = True
         packet = self.control_stream.read_request()
         assert packet.payload == HANDSHAKE_STRING
         # we expect the payload to be pure ASCII. ASCII and utf-8 overlap, so passing
@@ -206,6 +205,7 @@ class Connection:
         self.control_stream.write_reply_bytes(
             packet.message_id, f"Hegel/{PROTOCOL_VERSION}".encode("ascii")
         )
+        self._handshake_done = True
 
     def _make_stream(self, stream_id: StreamId, *, role: str | None = None) -> "Stream":
         """Create and register a stream."""

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -110,7 +110,6 @@ class Connection:
         self.running = True
 
         self.__writer_lock = Lock()
-        self.__close_lock = Lock()
         self.__socket = socket
         self.__next_stream_id = 1
         self._handshake_done = False
@@ -159,14 +158,10 @@ class Connection:
 
     def close(self) -> None:
         """Close the connection and clean up resources."""
-        with self.__close_lock:
+        with self.__writer_lock:
             if not self.running:
                 return
             self.running = False
-
-        # Hold the writer lock while closing the socket so that no
-        # write_packet call can be in flight when the fd is closed.
-        with self.__writer_lock:
             with contextlib.suppress(OSError):
                 self.__socket.shutdown(socket.SHUT_RDWR)
             with contextlib.suppress(OSError):

--- a/src/hegel/protocol/packet.py
+++ b/src/hegel/protocol/packet.py
@@ -83,7 +83,8 @@ class Packet:
 
 def read_exact(sock: socket.socket, *, n: int) -> bytes:
     """Read exactly n bytes from the socket."""
-    assert n >= 0
+    if n < 0:
+        raise ValueError(f"read_exact: n must be non-negative, got {n}")
     if n == 0:
         return b""
 
@@ -109,7 +110,10 @@ def read_packet(sock: socket.socket, *, timeout: float | None = None) -> Packet:
     magic, checksum, stream, message_id, length = struct.unpack(
         PACKET_HEADER_FORMAT, header
     )
-    assert magic == PACKET_MAGIC
+    if magic != PACKET_MAGIC:
+        raise ProtocolError(
+            f"Bad magic: expected 0x{PACKET_MAGIC:08X}, got 0x{magic:08X}"
+        )
 
     is_reply = (message_id & REPLY_BIT) != 0
     if is_reply:
@@ -117,12 +121,16 @@ def read_packet(sock: socket.socket, *, timeout: float | None = None) -> Packet:
 
     payload = read_exact(sock, n=length)
     terminator = read_exact(sock, n=1)[0]
-    assert terminator == PACKET_TERMINATOR
+    if terminator != PACKET_TERMINATOR:
+        raise ProtocolError(
+            f"Bad terminator: expected 0x{PACKET_TERMINATOR:02X}, got 0x{terminator:02X}"
+        )
 
     # checksum is defined as crc(header + payload), where the header's checksum has
     # been zeroed
     zeroed_header = header[:4] + b"\x00\x00\x00\x00" + header[8:]
-    assert zlib.crc32(zeroed_header + payload) == checksum
+    if zlib.crc32(zeroed_header + payload) != checksum:
+        raise ProtocolError("Packet checksum mismatch")
 
     return Packet(
         stream_id=stream,

--- a/src/hegel/protocol/stream.py
+++ b/src/hegel/protocol/stream.py
@@ -1,5 +1,6 @@
 from collections import deque
 from queue import Empty, SimpleQueue
+from threading import Lock
 from typing import TYPE_CHECKING, Any
 
 import cbor2
@@ -73,6 +74,8 @@ class Stream:
         self.replies: dict[MessageId, Packet] = {}
 
         self.next_message_id = MessageId(1)
+        self._write_lock = Lock()
+        self._close_lock = Lock()
         self.closed = False
 
     def __repr__(self):
@@ -84,10 +87,10 @@ class Stream:
 
     def close(self):
         """Close this stream. Writes a close stream notification packet to the socket."""
-        if self.closed:
-            return
-
-        self.closed = True
+        with self._close_lock:
+            if self.closed:
+                return
+            self.closed = True
         self.unprocessed_packets.put(SHUTDOWN)
         if self.connection.running:
             self.connection.write_packet(
@@ -148,14 +151,15 @@ class Stream:
     def write_request(self, payload: bytes) -> Packet:
         """Write a request packet to the socket. Returns the packet."""
         assert isinstance(payload, bytes)
-        packet = Packet(
-            payload=payload,
-            stream_id=self.stream_id,
-            is_reply=False,
-            message_id=self.next_message_id,
-        )
-        self.connection.write_packet(packet)
-        self.next_message_id = MessageId(self.next_message_id + 1)
+        with self._write_lock:
+            packet = Packet(
+                payload=payload,
+                stream_id=self.stream_id,
+                is_reply=False,
+                message_id=self.next_message_id,
+            )
+            self.connection.write_packet(packet)
+            self.next_message_id = MessageId(self.next_message_id + 1)
         return packet
 
     def write_reply(self, message_id: MessageId, value: Any) -> None:

--- a/src/hegel/protocol/stream.py
+++ b/src/hegel/protocol/stream.py
@@ -15,6 +15,7 @@ from hegel.protocol.utils import (
     SHUTDOWN,
     STREAM_TIMEOUT,
     MessageId,
+    ProtocolError,
     RequestError,
     StreamId,
 )
@@ -64,7 +65,10 @@ class Stream:
         stream_id: StreamId,
         role: str | None = None,
     ) -> None:
-        assert stream_id > 0 or role == "Control"
+        if stream_id <= 0 and role != "Control":
+            raise ProtocolError(
+                f"Stream id must be positive (got {stream_id}), or role must be 'Control'"
+            )
 
         self.connection = connection
         self.stream_id = stream_id
@@ -155,7 +159,6 @@ class Stream:
 
     def write_request(self, payload: bytes) -> Packet:
         """Write a request packet to the socket. Returns the packet."""
-        assert isinstance(payload, bytes)
         with self._write_lock:
             packet = Packet(
                 payload=payload,
@@ -183,7 +186,6 @@ class Stream:
 
     def write_reply_bytes(self, message_id: MessageId, payload: bytes) -> None:
         """Write a reply packet to the socket."""
-        assert isinstance(payload, bytes)
         self.connection.write_packet(
             Packet(
                 payload=payload,

--- a/src/hegel/protocol/stream.py
+++ b/src/hegel/protocol/stream.py
@@ -1,3 +1,4 @@
+import sys
 from collections import deque
 from queue import Empty, SimpleQueue
 from threading import Lock
@@ -120,7 +121,11 @@ class Stream:
             raise ConnectionError("Connection closed")
 
         if packet.is_reply:
-            assert packet.message_id not in self.replies
+            if packet.message_id in self.replies:
+                print(
+                    f"Duplicate reply for message_id {packet.message_id} on {self!r}",
+                    file=sys.stderr,
+                )
             self.replies[packet.message_id] = packet
         else:
             self.requests.append(packet)

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -129,7 +129,6 @@ class Variables:
                 else:
                     data.stop_span(discard=True)
             i = len(self.variables) - 1
-            assert i >= 0
             v = self.variables[i]
             data.draw_integer(
                 min_value=0,
@@ -230,14 +229,16 @@ class HegelState:
                             data.conclude_test(Status.VALID)
                         elif status is Status.INVALID:
                             data.mark_invalid()
-                        else:
-                            assert status is Status.INTERESTING
+                        elif status is Status.INTERESTING:
                             data.mark_interesting(
                                 origin,  # type: ignore[arg-type]
                             )
+                        else:
+                            raise ValueError(
+                                f"Unexpected mark_complete status: {status}"
+                            )
                     elif command == "new_collection":
                         collection_id = next(collection_id_counter)
-                        assert collection_id not in collections
                         min_size = message.get("min_size", 0)
                         max_size = message.get("max_size", float("inf"))
                         if max_size is None:

--- a/src/hegel/test_server.py
+++ b/src/hegel/test_server.py
@@ -64,7 +64,10 @@ def run_test_server(connection: Connection, mode: str) -> None:
         # Wait for run_test command on control stream
         packet = connection.control_stream.read_request()
         message = cbor2.loads(packet.payload)
-        assert message.get("command") == "run_test"
+        if message.get("command") != "run_test":
+            raise ValueError(
+                f"Expected run_test command, got {message.get('command')!r}"
+            )
         test_stream = connection.register_client_stream(
             message["stream_id"],
             role="Test stream",
@@ -107,14 +110,18 @@ def _read_cbor_request(
 def _handle_normal_generate(data_stream: Stream) -> None:
     """Handle generate commands normally, returning a boolean value."""
     msg_id, message = _read_cbor_request(data_stream)
-    assert message.get("command") == "generate"
+    if message.get("command") != "generate":
+        raise ValueError(f"Expected generate command, got {message.get('command')!r}")
     data_stream.write_reply(msg_id, True)
 
 
 def _wait_for_mark_complete(data_stream: Stream) -> tuple[MessageId, dict]:
     """Wait for mark_complete command from client."""
     msg_id, message = _read_cbor_request(data_stream)
-    assert message.get("command") == "mark_complete"
+    if message.get("command") != "mark_complete":
+        raise ValueError(
+            f"Expected mark_complete command, got {message.get('command')!r}"
+        )
     return msg_id, message
 
 
@@ -155,7 +162,8 @@ def _mode_stop_test_on_generate(
     # Second test case: StopTest on generate
     data_stream_2 = _send_test_case(connection, test_stream)
     msg_id, message = _read_cbor_request(data_stream_2)
-    assert message.get("command") == "generate"
+    if message.get("command") != "generate":
+        raise ValueError(f"Expected generate command, got {message.get('command')!r}")
     data_stream_2.write_reply_error(msg_id, error="StopTest", error_type="StopTest")
 
     # Wait briefly to see if client incorrectly sends mark_complete
@@ -274,7 +282,8 @@ def _mode_error_response(
     data_stream = _send_test_case(connection, test_stream)
 
     msg_id, message = _read_cbor_request(data_stream)
-    assert message.get("command") == "generate"
+    if message.get("command") != "generate":
+        raise ValueError(f"Expected generate command, got {message.get('command')!r}")
     data_stream.write_reply_error(
         msg_id,
         error="Simulated error for testing",

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -887,6 +887,41 @@ def test_write_packet_after_close_raises(socket):
         )
 
 
+def test_handshake_flag_is_false_until_handshake_completes(socket_pair):
+    """Regression: receive_handshake used to set self._handshake_done = True
+    as its first statement, so the assert in new_stream could pass while
+    the server was still waiting for the client's handshake bytes.
+    """
+    import threading as _threading
+
+    server_socket, client_socket = socket_pair
+    server_conn = Connection(server_socket)
+
+    read_entered = _threading.Event()
+    orig_read_request = server_conn.control_stream.read_request
+
+    def hooked_read_request(*args, **kwargs):
+        read_entered.set()
+        return orig_read_request(*args, **kwargs)
+
+    server_conn.control_stream.read_request = hooked_read_request
+
+    t = Thread(target=server_conn.receive_handshake, daemon=True)
+    t.start()
+    assert read_entered.wait(timeout=2.0)
+
+    with pytest.raises(AssertionError):
+        server_conn.new_stream()
+
+    client_conn = ClientConnection(client_socket)
+    client_conn.send_handshake()
+    t.join(timeout=5)
+
+    server_conn.new_stream()
+    client_conn.close()
+    server_conn.close()
+
+
 def test_invalid_hegel_debug_env_var():
     result = subprocess.run(
         [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,7 +9,7 @@ import pytest
 
 from hegel.protocol import Connection, Packet, RequestError
 from hegel.protocol.connection import PROTOCOL_VERSION
-from hegel.protocol.utils import SHUTDOWN
+from hegel.protocol.utils import SHUTDOWN, ProtocolError
 from tests.client import ClientConnection
 
 
@@ -609,7 +609,7 @@ def test_double_handshake_receive_raises(socket_pair):
 
         def server_side():
             server_conn.receive_handshake()
-            with pytest.raises(AssertionError):
+            with pytest.raises(ProtocolError, match="Handshake already completed"):
                 server_conn.receive_handshake()
 
         t = Thread(target=server_side, daemon=True)
@@ -622,7 +622,7 @@ def test_connect_stream_before_handshake_raises(socket):
     """Test that connect_stream before handshake raises."""
     with (
         Connection(socket) as conn,
-        pytest.raises(AssertionError),
+        pytest.raises(ProtocolError, match="Cannot register streams before handshake"),
     ):
         conn.register_client_stream(1)
 
@@ -637,7 +637,7 @@ def test_connect_stream_already_exists_raises(socket_pair):
         _do_handshake(server_conn, client_conn)
 
         # Connect to stream 0 which already exists (control stream)
-        with pytest.raises(AssertionError):
+        with pytest.raises(ProtocolError, match="already registered"):
             server_conn.register_client_stream(0)
 
 
@@ -645,13 +645,35 @@ def test_new_stream_before_handshake_raises(socket):
     """Test that new_stream before handshake raises."""
     with (
         Connection(socket) as conn,
-        pytest.raises(AssertionError),
+        pytest.raises(ProtocolError, match="Cannot create streams before handshake"),
     ):
         conn.new_stream()
 
 
+def test_make_stream_duplicate_raises(socket):
+    """Test that _make_stream rejects a duplicate stream id."""
+    with Connection(socket) as conn:
+        conn._handshake_done = True
+        conn._make_stream(1, role="First")
+        with pytest.raises(ProtocolError, match="already registered"):
+            conn._make_stream(1, role="Duplicate")
+
+
+def test_register_client_stream_even_id_raises(socket_pair):
+    """Test that registering a client stream with an even id raises."""
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+
+        with pytest.raises(ProtocolError, match="Client stream id must be odd"):
+            server_conn.register_client_stream(2)
+
+
 def test_bad_handshake_negotiation(socket_pair):
-    """Test handshake with bad version string asserts."""
+    """Test handshake with bad version string raises."""
     server_socket, client_socket = socket_pair
     with (
         Connection(server_socket) as server_conn,
@@ -665,7 +687,7 @@ def test_bad_handshake_negotiation(socket_pair):
         t = Thread(target=send_bad, daemon=True)
         t.start()
 
-        with pytest.raises(AssertionError):
+        with pytest.raises(ProtocolError, match="Bad handshake"):
             server_conn.receive_handshake()
 
         t.join(timeout=5)
@@ -1050,6 +1072,17 @@ def test_write_request_concurrent_message_ids_unique(socket_pair):
         assert len(set(results)) == n_workers
 
 
+def test_stream_constructor_rejects_non_control_stream_id_zero(socket):
+    """Test that creating a stream with id 0 and non-Control role raises."""
+    from hegel.protocol.stream import Stream
+
+    with (
+        Connection(socket) as conn,
+        pytest.raises(ProtocolError, match="Stream id must be positive"),
+    ):
+        Stream(connection=conn, stream_id=0, role="NotControl")
+
+
 def test_write_packet_after_close_raises(socket):
     """Test that write_packet raises ConnectionError after close."""
     conn = Connection(socket)
@@ -1083,7 +1116,7 @@ def test_handshake_flag_is_false_until_handshake_completes(socket_pair):
     t.start()
     assert read_entered.wait(timeout=2.0)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(ProtocolError, match="Cannot create streams before handshake"):
         server_conn.new_stream()
 
     client_conn = ClientConnection(client_socket)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -620,6 +620,273 @@ def test_reader_loop_graceful_exit_on_remote_close(socket_pair):
         server_conn.close()
 
 
+def test_stream_close_emits_exactly_one_close_packet(socket_pair):
+    """Regression: Stream.close() is check-then-set on self.closed, so N
+    concurrent callers could all pass the guard and each emit a CLOSE_STREAM
+    packet. The peer must see exactly one.
+
+    The race is between two bytecodes and the GIL scheduler does not reliably
+    preempt there, so we force a yield point by swapping in a subclass whose
+    ``closed`` is a property that blocks on a Barrier while its value is False.
+    """
+    import threading as _threading
+
+    from hegel.protocol.packet import CLOSE_STREAM_PAYLOAD
+    from hegel.protocol.stream import Stream
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+        stream = server_conn.new_stream()
+
+        n_workers = 16
+        check_barrier = _threading.Barrier(n_workers)
+        closed_box = [False]
+
+        class RaceyStream(Stream):
+            @property
+            def closed(self):
+                val = closed_box[0]
+                if not val:
+                    try:
+                        check_barrier.wait(timeout=2.0)
+                    except _threading.BrokenBarrierError:
+                        pass
+                return val
+
+            @closed.setter
+            def closed(self, value):
+                closed_box[0] = value
+
+        # Property on the class takes precedence over the instance attribute,
+        # but strip the stale instance attribute for clarity.
+        stream.__dict__.pop("closed", None)
+        stream.__class__ = RaceyStream
+
+        close_packet_count = 0
+        count_lock = _threading.Lock()
+        orig_write_packet = server_conn.write_packet
+
+        def counting_write_packet(packet):
+            nonlocal close_packet_count
+            if (
+                packet.payload == CLOSE_STREAM_PAYLOAD
+                and packet.stream_id == stream.stream_id
+            ):
+                with count_lock:
+                    close_packet_count += 1
+            orig_write_packet(packet)
+
+        server_conn.write_packet = counting_write_packet
+
+        def worker():
+            stream.close()
+
+        threads = [Thread(target=worker, daemon=True) for _ in range(n_workers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert close_packet_count == 1
+
+
+def test_connection_close_body_runs_once(socket_pair):
+    """Regression: Connection.close() is check-then-set on self.running, so N
+    concurrent callers could all pass the guard and each enqueue SHUTDOWN on
+    every stream. SHUTDOWN must be enqueued exactly once per stream.
+
+    As with Stream.close, we force a yield point by swapping in a subclass
+    whose ``running`` is a property that blocks on a Barrier while True.
+    """
+    import threading as _threading
+
+    server_socket, client_socket = socket_pair
+    server_conn = Connection(server_socket)
+    client_conn = ClientConnection(client_socket)
+    _do_handshake(server_conn, client_conn)
+    server_conn.new_stream()
+
+    n_workers = 16
+    check_barrier = _threading.Barrier(n_workers)
+    running_box = [True]
+
+    class RaceyConnection(Connection):
+        @property
+        def running(self):
+            val = running_box[0]
+            if val:
+                try:
+                    check_barrier.wait(timeout=2.0)
+                except _threading.BrokenBarrierError:
+                    pass
+            return val
+
+        @running.setter
+        def running(self, value):
+            running_box[0] = value
+
+    server_conn.__dict__.pop("running", None)
+    server_conn.__class__ = RaceyConnection
+
+    put_count = 0
+    count_lock = _threading.Lock()
+    real_q = server_conn.control_stream.unprocessed_packets
+
+    class CountingQueue:
+        def put(self, item):
+            if item is SHUTDOWN:
+                nonlocal put_count
+                with count_lock:
+                    put_count += 1
+            real_q.put(item)
+
+        def get(self, *args, **kwargs):
+            return real_q.get(*args, **kwargs)
+
+    server_conn.control_stream.unprocessed_packets = CountingQueue()
+
+    def worker():
+        server_conn.close()
+
+    threads = [Thread(target=worker, daemon=True) for _ in range(n_workers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    client_conn.close()
+
+    assert put_count == 1
+
+
+def test_close_tolerates_concurrent_new_stream(socket_pair):
+    """Regression: Connection.close() must not raise when a new stream is added
+    concurrently (previously iterated ``self.streams`` without the writer lock,
+    which could raise 'dictionary changed size during iteration').
+    """
+    import threading as _threading
+
+    server_socket, client_socket = socket_pair
+    server_conn = Connection(server_socket)
+    client_conn = ClientConnection(client_socket)
+    _do_handshake(server_conn, client_conn)
+    # A couple of streams so close() has something to iterate over.
+    server_conn.new_stream()
+    server_conn.new_stream()
+
+    # Block close()'s iteration inside the body so we have a window in which
+    # to mutate the streams dict from another thread.
+    first_stream = next(iter(server_conn.streams.values()))
+    iter_entered = _threading.Event()
+    release_iter = _threading.Event()
+    real_queue = first_stream.unprocessed_packets
+
+    class HookedQueue:
+        def put(self, item):
+            iter_entered.set()
+            release_iter.wait(timeout=5.0)
+            real_queue.put(item)
+
+        def get(self, *args, **kwargs):
+            return real_queue.get(*args, **kwargs)
+
+    first_stream.unprocessed_packets = HookedQueue()
+
+    errors = []
+
+    def closer():
+        try:
+            server_conn.close()
+        except Exception as e:
+            errors.append(("close", e))
+
+    def creator():
+        iter_entered.wait(timeout=5.0)
+        try:
+            server_conn.new_stream()
+        except Exception as e:
+            errors.append(("new_stream", e))
+        release_iter.set()
+
+    t_close = Thread(target=closer, daemon=True)
+    t_create = Thread(target=creator, daemon=True)
+    t_close.start()
+    t_create.start()
+    t_close.join(timeout=10)
+    t_create.join(timeout=10)
+
+    client_conn.close()
+
+    assert errors == []
+
+
+def test_write_request_concurrent_message_ids_unique(socket_pair):
+    """Concurrent write_request on the same stream must produce unique message IDs.
+
+    Regression test: the read-modify-write of ``Stream.next_message_id`` used
+    to be non-atomic, so two concurrent calls could both observe the same id
+    and emit two packets with the same message_id.
+    """
+    import threading as _threading
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+        stream = server_conn.new_stream()
+
+        n_workers = 8
+        barrier = _threading.Barrier(n_workers)
+        orig_write_packet = server_conn.write_packet
+
+        def patched_write_packet(packet):
+            # Force all workers to sit here with their message_id already read
+            # from self.next_message_id. Under the bug they all captured the
+            # same value; under the fix only one worker can be mid-write at a
+            # time, so the first arrival times out the barrier and the rest
+            # proceed through the (now broken) barrier immediately.
+            try:
+                barrier.wait(timeout=0.5)
+            except _threading.BrokenBarrierError:
+                pass
+            orig_write_packet(packet)
+
+        server_conn.write_packet = patched_write_packet
+
+        results = []
+        results_lock = _threading.Lock()
+
+        def worker():
+            packet = stream.write_request(cbor2.dumps({"n": 1}))
+            with results_lock:
+                results.append(packet.message_id)
+
+        threads = [Thread(target=worker, daemon=True) for _ in range(n_workers)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert len(results) == n_workers
+        assert len(set(results)) == n_workers
+
+
+def test_write_packet_after_close_raises(socket):
+    """Test that write_packet raises ConnectionError after close."""
+    conn = Connection(socket)
+    conn.close()
+    with pytest.raises(ConnectionError, match="Connection closed"):
+        conn.write_packet(
+            Packet(stream_id=0, message_id=1, is_reply=False, payload=b"test")
+        )
+
+
 def test_invalid_hegel_debug_env_var():
     result = subprocess.run(
         [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -82,6 +82,13 @@ def test_connection_debug_mode(socket, name, payload):
         conn._debug_packet(packet, direction="TEST")
 
 
+def test_connection_debug_unknown_stream(socket):
+    """_debug_packet handles packets for unknown stream_ids without crashing."""
+    with Connection(socket, name="Dbg", debug=True) as conn:
+        packet = Packet(stream_id=9999, message_id=1, is_reply=False, payload=b"hello")
+        conn._debug_packet(packet, direction="TEST")
+
+
 @pytest.mark.parametrize(
     "send_fn",
     [
@@ -198,8 +205,14 @@ def test_stream_repr_variations(socket_pair, role, expected):
         assert expected in repr(stream)
 
 
-def test_message_to_closed_stream(socket_pair):
-    """Test sending a message to a closed stream."""
+def test_request_to_closed_stream_gets_error_reply(socket_pair):
+    """Sending a request to a server-closed stream gets an error reply.
+
+    The server must not crash, and the client receives a ProtocolError so
+    it fails fast rather than hanging.
+    """
+    from hegel.protocol.packet import CLOSE_STREAM_PAYLOAD, read_packet
+
     server_socket, client_socket = socket_pair
     with (
         Connection(server_socket) as server_conn,
@@ -210,13 +223,174 @@ def test_message_to_closed_stream(socket_pair):
         ch_server = server_conn.new_stream()
         ch_client = client_conn.connect_stream(ch_server.stream_id)
 
-        # Close the stream on server side
         ch_server.close()
         time.sleep(0.2)
 
-        # Now send a request to the closed stream from client
-        ch_client.write_request(cbor2.dumps({"test": "data"}))
+        packet = ch_client.write_request(cbor2.dumps({"test": "data"}))
+
+        # Skip the close notification packet, find our error reply.
+        while True:
+            reply = read_packet(client_socket, timeout=2.0)
+            if reply.payload == CLOSE_STREAM_PAYLOAD:
+                continue
+            if reply.is_reply and reply.message_id == packet.message_id:
+                break
+
+        assert reply.stream_id == ch_server.stream_id
+        body = cbor2.loads(reply.payload)
+        assert "error" in body
+        assert body["type"] == "ProtocolError"
+
+        assert server_conn.running
+        assert server_conn._reader_thread.is_alive()
+
+
+def test_request_for_unknown_stream_gets_error_reply(socket_pair):
+    """A request on an unregistered stream_id gets an error reply.
+
+    The server must not crash, and the client must receive a ProtocolError
+    reply so it fails fast rather than hanging.
+    """
+    from hegel.protocol.packet import read_packet, write_packet
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+
+        bogus_stream_id = 9999
+        write_packet(
+            client_socket,
+            Packet(
+                stream_id=bogus_stream_id,
+                message_id=1,
+                is_reply=False,
+                payload=cbor2.dumps({"bad": True}),
+            ),
+        )
+
+        reply = read_packet(client_socket, timeout=2.0)
+        assert reply.stream_id == bogus_stream_id
+        assert reply.message_id == 1
+        assert reply.is_reply
+        body = cbor2.loads(reply.payload)
+        assert "error" in body
+        assert body["type"] == "ProtocolError"
+
+        assert server_conn.running
+        assert server_conn._reader_thread.is_alive()
+
+        # Other streams still work.
+        ch_server = server_conn.new_stream()
+        ch_client = client_conn.connect_stream(ch_server.stream_id)
+
+        def server_handler():
+            @ch_server.handle_requests
+            def _(message):
+                return {"echo": message}
+
+        t = Thread(target=server_handler, daemon=True)
+        t.start()
+        assert ch_client.send_request({"ping": 1}) == {"echo": {"ping": 1}}
+
+
+def test_reply_for_unknown_stream_is_silently_discarded(socket_pair):
+    """A reply packet on an unregistered stream is discarded with no response."""
+    from hegel.protocol.packet import write_packet
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+
+        write_packet(
+            client_socket,
+            Packet(
+                stream_id=9999,
+                message_id=1,
+                is_reply=True,
+                payload=cbor2.dumps({"result": "stale"}),
+            ),
+        )
         time.sleep(0.2)
+
+        assert server_conn.running
+        assert server_conn._reader_thread.is_alive()
+
+
+def test_error_reply_write_failure_is_suppressed(socket_pair):
+    """If sending the error reply fails (e.g. connection closing), the reader
+    loop continues without crashing."""
+    from hegel.protocol.packet import write_packet as _write_packet
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+
+        orig_write = server_conn.write_packet
+
+        def failing_write(packet):
+            if packet.is_reply and packet.stream_id == 9999:
+                raise OSError("simulated write failure")
+            orig_write(packet)
+
+        server_conn.write_packet = failing_write
+
+        _write_packet(
+            client_socket,
+            Packet(
+                stream_id=9999,
+                message_id=1,
+                is_reply=False,
+                payload=cbor2.dumps({"bad": True}),
+            ),
+        )
+        time.sleep(0.2)
+
+        assert server_conn.running
+        assert server_conn._reader_thread.is_alive()
+
+
+def test_close_packet_with_wrong_message_id_is_discarded(socket_pair):
+    """A close-stream payload with the wrong message_id is silently discarded.
+
+    The reader loop must not crash with an AssertionError; the connection stays
+    alive.
+    """
+    from hegel.protocol.packet import CLOSE_STREAM_PAYLOAD, write_packet
+
+    server_socket, client_socket = socket_pair
+    with (
+        Connection(server_socket) as server_conn,
+        ClientConnection(client_socket) as client_conn,
+    ):
+        _do_handshake(server_conn, client_conn)
+
+        ch_client = client_conn.new_stream()
+        server_conn.register_client_stream(ch_client.stream_id)
+
+        # Send a close-stream payload but with the wrong message_id.
+        write_packet(
+            client_socket,
+            Packet(
+                stream_id=ch_client.stream_id,
+                message_id=42,  # wrong — should be CLOSE_STREAM_MESSAGE_ID
+                is_reply=False,
+                payload=CLOSE_STREAM_PAYLOAD,
+            ),
+        )
+        time.sleep(0.2)
+
+        # The connection must still be alive.
+        assert server_conn.running
+        assert server_conn._reader_thread.is_alive()
 
 
 @pytest.mark.parametrize("create_stream_first", [False, True])
@@ -406,21 +580,20 @@ def test_duplicate_reply_id_raises(socket):
         assert result == b"a"
 
 
-def test_duplicate_reply_error(socket):
-    """Test that duplicate replies for same ID raises AssertionError."""
+def test_duplicate_reply_warns_on_stderr(socket, capsys):
+    """Duplicate replies for same ID print a warning instead of crashing."""
     with Connection(socket) as conn:
         stream = conn.control_stream
 
-        # Put a reply in the replies dict directly
         stream.replies[42] = b"first"
 
-        # Now try to process another reply with same ID
         stream.unprocessed_packets.put(
             Packet(stream_id=0, message_id=42, is_reply=True, payload=b"second")
         )
 
-        with pytest.raises(AssertionError):
-            stream._Stream__read_one_packet()
+        stream._Stream__read_one_packet()
+        captured = capsys.readouterr()
+        assert "Duplicate reply for message_id 42" in captured.err
 
 
 # ---- Connection handshake ----

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -149,6 +149,18 @@ def test_stdio_transport_recv_eof():
     transport.close()
 
 
+def test_stdio_transport_sendall_after_close_raises_oserror():
+    """StdioTransport.sendall raises OSError (not ValueError) when writer is closed."""
+    import io
+
+    reader = io.BytesIO(b"")
+    writer = io.BytesIO(b"")
+    transport = StdioTransport(reader, writer)
+    transport.close()
+    with pytest.raises(OSError):
+        transport.sendall(b"hello")
+
+
 def test_stdio_transport_recv_none():
     """Cover the `data is None` branch in recv."""
 

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -76,7 +76,7 @@ def test_read_packet_invalid_magic(socket_pair):
     reader, writer = socket_pair
     raw = _make_packet(magic=0xDEADBEEF)
     writer.sendall(raw)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ProtocolError, match="Bad magic"):
         read_packet(reader)
 
 
@@ -84,7 +84,7 @@ def test_read_packet_invalid_terminator(socket_pair):
     reader, writer = socket_pair
     raw = _make_packet(terminator=0xFF)
     writer.sendall(raw)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ProtocolError, match="Bad terminator"):
         read_packet(reader)
 
 
@@ -92,5 +92,11 @@ def test_read_packet_bad_checksum(socket_pair):
     reader, writer = socket_pair
     raw = _make_packet(checksum=0x12345678)
     writer.sendall(raw)
-    with pytest.raises(AssertionError):
+    with pytest.raises(ProtocolError, match="checksum mismatch"):
         read_packet(reader)
+
+
+def test_read_exact_negative_n(socket_pair):
+    reader, _ = socket_pair
+    with pytest.raises(ValueError, match="non-negative"):
+        read_exact(reader, n=-1)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -64,6 +64,17 @@ def test_unknown_command_on_data_stream(client):
     client.run_test(test, test_cases=1)
 
 
+def test_mark_complete_with_overrun_status_raises(client):
+    """Sending mark_complete with OVERRUN status is rejected by the server."""
+
+    def test():
+        generate_from_schema({"type": "integer"})
+        with pytest.raises(RequestError, match="Unexpected mark_complete status"):
+            _request({"command": "mark_complete", "status": "OVERRUN", "origin": None})
+
+    client.run_test(test, test_cases=1)
+
+
 def test_cache_eviction():
     # Fill the cache beyond its max size
     for i in range(FROM_SCHEMA_CACHE.max_size + 10):

--- a/tests/test_test_server.py
+++ b/tests/test_test_server.py
@@ -468,3 +468,144 @@ class TestTestServerErrors:
             t.join(timeout=5.0)
             assert len(errors) == 1
             assert "nonexistent_mode" in str(errors[0])
+
+
+class TestTestServerCommandValidation:
+    def test_non_run_test_command_raises(self):
+        """Test that sending a non-run_test command raises ValueError."""
+        s1, s2 = _create_socket_pair()
+        errors = []
+
+        def run():
+            conn = Connection(s1)
+            try:
+                run_test_server(conn, "empty_test")
+            except ValueError as e:
+                errors.append(e)
+
+        t = Thread(target=run, daemon=True)
+        t.start()
+
+        with _setup_client(s2) as conn:
+            conn.control_stream.write_request(
+                cbor2.dumps({"command": "bogus"}),
+            )
+
+        t.join(timeout=5.0)
+        assert len(errors) == 1
+        assert "Expected run_test" in str(errors[0])
+
+    def test_non_generate_command_raises_in_handle_normal_generate(self):
+        """Test _handle_normal_generate raises when client sends wrong command."""
+        s1, s2 = _create_socket_pair()
+        errors = []
+
+        def run():
+            conn = Connection(s1)
+            try:
+                run_test_server(conn, "stop_test_on_generate")
+            except ValueError as e:
+                errors.append(e)
+
+        t = Thread(target=run, daemon=True)
+        t.start()
+
+        with _setup_client(s2) as conn:
+            test_stream = _send_run_test(conn)
+            data_ch1, _ = _receive_test_case(test_stream, conn)
+            data_ch1.write_request(
+                cbor2.dumps(
+                    {"command": "mark_complete", "status": "VALID", "origin": None}
+                ),
+            )
+
+        t.join(timeout=5.0)
+        assert len(errors) == 1
+        assert "Expected generate" in str(errors[0])
+
+    def test_non_mark_complete_command_raises_in_wait_for_mark_complete(self):
+        """Test _wait_for_mark_complete raises when client sends wrong command."""
+        s1, s2 = _create_socket_pair()
+        errors = []
+
+        def run():
+            conn = Connection(s1)
+            try:
+                run_test_server(conn, "stop_test_on_mark_complete")
+            except ValueError as e:
+                errors.append(e)
+
+        t = Thread(target=run, daemon=True)
+        t.start()
+
+        with _setup_client(s2) as conn:
+            test_stream = _send_run_test(conn)
+            data_ch, _ = _receive_test_case(test_stream, conn)
+            _send_generate(data_ch)
+            data_ch.write_request(
+                cbor2.dumps({"command": "generate", "schema": {"type": "boolean"}}),
+            )
+
+        t.join(timeout=5.0)
+        assert len(errors) == 1
+        assert "Expected mark_complete" in str(errors[0])
+
+    def test_non_generate_in_stop_test_mode_second_test_case(self):
+        """Test _mode_stop_test_on_generate raises for wrong command on 2nd test case."""
+        s1, s2 = _create_socket_pair()
+        errors = []
+
+        def run():
+            conn = Connection(s1)
+            try:
+                run_test_server(conn, "stop_test_on_generate")
+            except ValueError as e:
+                errors.append(e)
+
+        t = Thread(target=run, daemon=True)
+        t.start()
+
+        with _setup_client(s2) as conn:
+            test_stream = _send_run_test(conn)
+            data_ch1, _ = _receive_test_case(test_stream, conn)
+            _send_generate(data_ch1)
+            _send_mark_complete(data_ch1)
+
+            data_ch2, _ = _receive_test_case(test_stream, conn)
+            data_ch2.write_request(
+                cbor2.dumps(
+                    {"command": "mark_complete", "status": "VALID", "origin": None}
+                ),
+            )
+
+        t.join(timeout=5.0)
+        assert len(errors) == 1
+        assert "Expected generate" in str(errors[0])
+
+    def test_non_generate_in_error_response_mode(self):
+        """Test _mode_error_response raises for wrong command."""
+        s1, s2 = _create_socket_pair()
+        errors = []
+
+        def run():
+            conn = Connection(s1)
+            try:
+                run_test_server(conn, "error_response")
+            except ValueError as e:
+                errors.append(e)
+
+        t = Thread(target=run, daemon=True)
+        t.start()
+
+        with _setup_client(s2) as conn:
+            test_stream = _send_run_test(conn)
+            data_ch, _ = _receive_test_case(test_stream, conn)
+            data_ch.write_request(
+                cbor2.dumps(
+                    {"command": "mark_complete", "status": "VALID", "origin": None}
+                ),
+            )
+
+        t.join(timeout=5.0)
+        assert len(errors) == 1
+        assert "Expected generate" in str(errors[0])


### PR DESCRIPTION
I'm still trying to track down why we're getting flaky tests on hegel-rust. This is a collection of fixes to try to make the hegel-core server more robust and easier to debug.

I don't actually believe that any of these is the root cause, but I do believe they are all worthy improvements in their own right.