### PR TITLE
Remove unix socket support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -43,7 +43,7 @@ Binary protocol over stdin/stdout with CBOR-encoded payloads:
 
 ### Module Overview
 
-- `__main__.py` - CLI entry point (`hegel` command via click). Speaks the protocol over stdin/stdout. The `--stdio` flag is accepted for backward compatibility but is a no-op.
+- `__main__.py` - CLI entry point (`hegel` command via click). Speaks the protocol over stdin/stdout.
 - `server.py` - Drives test execution via Hypothesis `ConjectureRunner` with a `ThreadPoolExecutor`. Contains `HegelState` (per-test-run state) and `_run_test` (orchestrates a full test including shrinking and final replay)
 - `protocol/` - Binary protocol package:
   - `packet.py` - Wire format: `Packet` dataclass, `read_packet`/`write_packet` for serialization with CRC32 checksums

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -112,4 +112,4 @@ The first line must be `RELEASE_TYPE: major`, `RELEASE_TYPE: minor`, or `RELEASE
 
 ### Writing Changelog Entries
 
-When writing a `RELEASE.md`, read `.claude/changelog-guidance.md` for detailed style guidance.
+When writing a `RELEASE.md`, invoke the `changelog` skill (see `.claude/skills/changelog/SKILL.md`) for detailed style guidance.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Hegel is a universal property-based testing protocol. A Python server (powered by Hypothesis) communicates with language-specific client libraries via Unix sockets. This repository contains the Python core server.
+Hegel is a universal property-based testing protocol. A Python server (powered by Hypothesis) communicates with language-specific client libraries over the server's stdin/stdout. This repository contains the Python core server.
 
 ## Build & Test Commands
 
@@ -29,14 +29,13 @@ Coverage runs twice in CI: once normally and once with `ANTITHESIS_OUTPUT_DIR` s
 
 ### Client-Server Communication
 
-1. **Client** creates a Unix socket path and spawns the `hegel` CLI with that path
-2. **The server** binds to the socket and listens for the client to connect
-3. A single persistent connection supports multiple test executions
-4. **Hypothesis ConjectureRunner** drives test execution on the server side, including shrinking
+1. **Client** spawns the `hegel` CLI as a subprocess and communicates over its stdin/stdout
+2. A single persistent connection supports multiple test executions
+3. **Hypothesis ConjectureRunner** drives test execution on the server side, including shrinking
 
 ### Protocol
 
-Binary protocol over Unix socket with CBOR-encoded payloads:
+Binary protocol over stdin/stdout with CBOR-encoded payloads:
 - 20-byte header + variable payload + terminator byte: magic `0x4845474C` (HEGL), CRC32, stream ID, message ID, payload length
 - Stream 0 is the control stream; odd-numbered streams are client-created, even-numbered are server-created
 - Reply bit (`1 << 31`) in message ID distinguishes requests from replies
@@ -44,7 +43,7 @@ Binary protocol over Unix socket with CBOR-encoded payloads:
 
 ### Module Overview
 
-- `__main__.py` - CLI entry point (`hegel` command via click), binds Unix socket and starts server
+- `__main__.py` - CLI entry point (`hegel` command via click). Speaks the protocol over stdin/stdout. The `--stdio` flag is accepted for backward compatibility but is a no-op.
 - `server.py` - Drives test execution via Hypothesis `ConjectureRunner` with a `ThreadPoolExecutor`. Contains `HegelState` (per-test-run state) and `_run_test` (orchestrates a full test including shrinking and final replay)
 - `protocol/` - Binary protocol package:
   - `packet.py` - Wire format: `Packet` dataclass, `read_packet`/`write_packet` for serialization with CRC32 checksums
@@ -67,7 +66,7 @@ Binary protocol over Unix socket with CBOR-encoded payloads:
 
 ### Generator Modes
 
-1. **Schema Composition** (preferred): Compose JSON schemas, single socket request. Generators that have schemas are called "basic generators."
+1. **Schema Composition** (preferred): Compose JSON schemas, single protocol request. Generators that have schemas are called "basic generators."
 2. **Compositional Fallback**: Multiple requests wrapped in spans when schemas unavailable (after `map`/`filter` on non-basic generators, or `flatmap`)
 
 Key insight: `map()` on a basic generator preserves the schema by composing the transform function, rather than losing it. This is the central optimization across all libraries.

--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: changelog
+description: "Changelog style guide for writing RELEASE.md files. Use when creating or reviewing RELEASE.md, writing changelog entries, or preparing a PR that needs release notes."
+---
+
 # Changelog Style Guide
 
 This guide describes the style for writing `RELEASE.md` files for hegel-core. The style is modeled on the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html).
@@ -80,7 +85,7 @@ Don't include code blocks for bug fixes or internal changes.
 ```
 RELEASE_TYPE: patch
 
-This patch fixes `generators::hashsets` generating duplicate elements in rare cases when the element generator had a very small output space.
+This patch fixes a rare deadlock in the protocol reader when a stream was closed concurrently with an in-flight request.
 ```
 
 **Good patch (internal):**

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release removes the Unix socket transport from the `hegel` server. The
+This patch removes the Unix socket transport from the `hegel` server. The
 server now always communicates with clients over its stdin/stdout. The
 positional `socket_path` argument has been removed from the CLI; the `--stdio`
 flag is still accepted for backward compatibility with existing callers, but

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch removes the Unix socket transport from the `hegel` server. The
-server now always communicates with clients over its stdin/stdout. The
-positional `socket_path` argument has been removed from the CLI; the `--stdio`
-flag is still accepted for backward compatibility with existing callers, but
-is now a no-op (stdio is the only mode).
-
-Library implementations should spawn `hegel` (with or without `--stdio`) and
-read and write the binary protocol on the subprocess's stdout and stdin.
+This patch removes the unused Unix socket transport from the `hegel` server. The server now always communicates with its client over stdin/stdout, matching how all current libraries spawn it. The CLI's `--stdio` flag is still accepted for backward compatibility, but is now a no-op.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 RELEASE_TYPE: patch
 
-This patch removes the unused Unix socket transport from the `hegel` server. The server now always communicates with its client over stdin/stdout, matching how all current libraries spawn it. The CLI's `--stdio` flag is still accepted for backward compatibility, but is now a no-op.
+This patch removes the unused Unix socket transport from the `hegel` server. The server now always communicates with its client over stdin/stdout, matching how all current libraries spawn it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release removes the Unix socket transport from the `hegel` server. The
+server now always communicates with clients over its stdin/stdout. The
+positional `socket_path` argument has been removed from the CLI; the `--stdio`
+flag is still accepted for backward compatibility with existing callers, but
+is now a no-op (stdio is the only mode).
+
+Library implementations should spawn `hegel` (with or without `--stdio`) and
+read and write the binary protocol on the subprocess's stdout and stdin.

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -5,18 +5,19 @@ covers the public API, protocol, design guidance, and implementation checklist.
 
 ## Overview
 
-A Hegel library enables property-based testing from any language by communicating
-with the Hegel server via Unix socket. The library provides:
+A Hegel library enables property-based testing from any language by spawning
+the `hegel` CLI as a subprocess and communicating with it over its
+stdin/stdout. The library provides:
 
 1. **Generator types** that produce random values according to constraints
 2. **Combinators** for composing generators into complex structures
-3. **Socket communication** to request values from Hypothesis's generation engine
+3. **Subprocess communication** to request values from Hypothesis's generation engine
 4. **Schema composition** for efficient single-request generation
 
 ### Core Principles
 
 - **Schema composition preferred**: When possible, compose schemas and make a
-  single socket request for the entire structure.
+  single protocol request for the entire structure.
 - **Compositional fallback**: When schemas are unavailable (after `map`/`filter`
   on non-basic generators, or `flat_map`), generate structurally with multiple
   requests.
@@ -591,16 +592,20 @@ will try to maximize the target value, which can help find edge cases.
 ## Protocol
 
 Client libraries communicate with the Hegel server via a binary protocol over
-Unix domain sockets.
+the server subprocess's stdin/stdout.
 
 ### Connection Lifecycle
 
-1. Client creates a socket path.
-2. Client spawns hegel server with that socket path.
-3. hegel server binds to the socket and listens.
-4. Client connects to the hegel server socket.
-5. A single persistent connection is maintained per program run.
-6. Multiple tests run over the same connection.
+1. Client spawns the `hegel` server as a subprocess, capturing its stdin and
+   stdout. (Stderr is left available for diagnostic output.)
+2. Client writes packets to the server's stdin and reads packets from its
+   stdout.
+3. A single persistent connection is maintained per program run.
+4. Multiple tests run over the same connection.
+
+The `hegel` CLI accepts a `--stdio` flag for backward compatibility with
+older callers, but it is a no-op: the server always communicates over
+stdin/stdout.
 
 ### Packet Format
 
@@ -858,8 +863,8 @@ labeled group.
 ### Reading packets from the Connection
 
 The Hegel protocol uses a **demand-driven reader** reader. When a stream needs
-a message, it drives the connection's reader to read from the socket until the
-needed message arrives (or a timeout is reached).
+a message, it drives the connection's reader to read from the transport until
+the needed message arrives (or a timeout is reached).
 
 **How it works:**
 
@@ -869,7 +874,7 @@ needed message arrives (or a timeout is reached).
    stream is closed, or a timeout expires.
 2. `run_reader` acquires a reader lock (non-blocking — if another thread holds
    it, the caller polls until the lock is free or `until` is true).
-3. While the lock is held, it reads packets from the socket (with short
+3. While the lock is held, it reads packets from the transport (with short
    timeouts to allow checking the `until` condition) and dispatches them to
    the appropriate stream's inbox.
 4. When `until()` returns true, the reader releases the lock and returns.
@@ -878,17 +883,17 @@ needed message arrives (or a timeout is reached).
 
 - **No background thread**: There is no dedicated reader thread. Reading
   happens on the calling thread when a stream needs data.
-- **Reader lock**: Only one thread reads from the socket at a time. The lock
-  is acquired non-blocking — other threads poll until it's available.
-- **Short read timeouts**: `read_packet` uses a short socket timeout (e.g.
+- **Reader lock**: Only one thread reads from the transport at a time. The
+  lock is acquired non-blocking — other threads poll until it's available.
+- **Short read timeouts**: `read_packet` uses a short read timeout (e.g.
   100ms) so the reader can periodically check the `until` condition.
-- **Close is simple**: Set `running = false`, shutdown the socket, close
+- **Close is simple**: Set `running = false`, close the transport, close
   streams. No thread join needed.
 
 **Thread safety for sends:**
 
 - A separate writer lock protects `send_packet` so multiple threads can
-  send concurrently without corrupting the socket stream.
+  send concurrently without corrupting the byte stream.
 - Stream registration also uses the writer lock.
 
 **Thread-local state:**

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -603,10 +603,6 @@ the server subprocess's stdin/stdout.
 3. A single persistent connection is maintained per program run.
 4. Multiple tests run over the same connection.
 
-The `hegel` CLI accepts a `--stdio` flag for backward compatibility with
-older callers, but it is a no-op: the server always communicates over
-stdin/stdout.
-
 ### Packet Format
 
 Each packet has a 20-byte header:

--- a/src/hegel/__main__.py
+++ b/src/hegel/__main__.py
@@ -1,9 +1,7 @@
 import contextlib
 import importlib.metadata
 import os
-import socket
 import sys
-from pathlib import Path
 
 import click
 from hypothesis import Verbosity
@@ -59,12 +57,12 @@ class StdioTransport:
     version=importlib.metadata.version("hegel-core"),
     message="hegel (version %(version)s)",
 )
-@click.argument("socket_path", required=False, default=None)
 @click.option(
     "--stdio",
+    "stdio",
     is_flag=True,
     default=False,
-    help="Use stdin/stdout for protocol communication instead of a Unix socket.",
+    help="Accepted for backward compatibility. The server always uses stdin/stdout.",
 )
 @click.option(
     "--verbosity",
@@ -72,57 +70,10 @@ class StdioTransport:
     default="normal",
     help="Verbosity level. Corresponds to hypothesis.Verbosity.",
 )
-def main(socket_path, stdio, verbosity):
-    """Run the Hegel test server, binding to socket_path."""
-    verbosity = Verbosity(verbosity)
-
-    if stdio:
-        if socket_path is not None:
-            raise click.UsageError("Cannot specify a socket path with --stdio.")
-        run_server_stdio(verbosity=verbosity)
-    else:
-        if socket_path is None:
-            raise click.UsageError("Socket path is required when not using --stdio.")
-        socket_path = Path(socket_path)
-
-        # Clean up any existing socket before starting
-        with contextlib.suppress(FileNotFoundError):
-            socket_path.unlink()
-
-        run_server(socket_path, verbosity=verbosity)
-
-
-def run_server(socket_path: Path, *, verbosity: Verbosity = Verbosity.normal) -> None:
-    if verbosity >= Verbosity.debug:
-        os.environ["HEGEL_PROTOCOL_DEBUG"] = "1"
-
-    set_hypothesis_home_dir(".hegel")
-
-    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    server_sock.bind(str(socket_path))
-    server_sock.listen(1)
-
-    if verbosity >= Verbosity.verbose:
-        print(f"Listening on {socket_path}", file=sys.stderr)
-
-    try:
-        client_sock, _ = server_sock.accept()
-
-        if verbosity >= Verbosity.verbose:
-            print("Client connected", file=sys.stderr)
-
-        connection = Connection(client_sock, name="Server")
-        test_mode = os.environ.get("HEGEL_PROTOCOL_TEST_MODE")
-        if test_mode:
-            run_test_server(connection, test_mode)
-        else:
-            run_server_on_connection(connection)
-
-        if verbosity >= Verbosity.verbose:
-            print("Client disconnected", file=sys.stderr)
-
-    finally:
-        server_sock.close()
+def main(stdio, verbosity):
+    """Run the Hegel test server, communicating over stdin/stdout."""
+    del stdio  # accepted for backward compatibility; stdio is the only mode
+    run_server_stdio(verbosity=Verbosity(verbosity))
 
 
 def run_server_stdio(*, verbosity: Verbosity = Verbosity.normal) -> None:

--- a/src/hegel/__main__.py
+++ b/src/hegel/__main__.py
@@ -58,21 +58,13 @@ class StdioTransport:
     message="hegel (version %(version)s)",
 )
 @click.option(
-    "--stdio",
-    "stdio",
-    is_flag=True,
-    default=False,
-    help="Accepted for backward compatibility. The server always uses stdin/stdout.",
-)
-@click.option(
     "--verbosity",
     type=click.Choice(["quiet", "normal", "verbose", "debug"]),
     default="normal",
     help="Verbosity level. Corresponds to hypothesis.Verbosity.",
 )
-def main(stdio, verbosity):
+def main(verbosity):
     """Run the Hegel test server, communicating over stdin/stdout."""
-    del stdio  # accepted for backward compatibility; stdio is the only mode
     run_server_stdio(verbosity=Verbosity(verbosity))
 
 

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -54,9 +54,9 @@ class Connection:
     A connection can be used simultaneously by multiple tests.
 
     At the lowest level, the protocol is bytes moving across the transport layer. The
-    transport layer is currently unix sockets, though this may change to support windows.
-    Bytes sent over the socket always consist of logical packets (see the Packet class).
-    Packets on the protocol have a stream_id, which logically organizes packets. See the
+    transport layer is the server subprocess's stdin/stdout. Bytes sent over the
+    transport always consist of logical packets (see the Packet class). Packets on
+    the protocol have a stream_id, which logically organizes packets. See the
     Stream class for details.
 
     Protocol

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -93,20 +93,7 @@ def test_stdio_transport_recv_none():
 # --- CLI tests ---
 
 
-def test_cli_stdio_flag_is_accepted(monkeypatch):
-    """--stdio is kept for compatibility but is a no-op (stdio is the only mode)."""
-    called = []
-    monkeypatch.setattr(
-        "hegel.__main__.run_server_stdio",
-        lambda **kwargs: called.append(kwargs),
-    )
-    result = CliRunner().invoke(main, ["--stdio"])
-    assert result.exit_code == 0
-    assert len(called) == 1
-
-
-def test_cli_no_stdio_flag_still_uses_stdio(monkeypatch):
-    """Without --stdio the server still runs in stdio mode."""
+def test_cli_invokes_run_server_stdio(monkeypatch):
     called = []
     monkeypatch.setattr(
         "hegel.__main__.run_server_stdio",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,9 +5,6 @@ import importlib.metadata
 import os
 import socket
 import sys
-import tempfile
-import time
-from pathlib import Path
 from threading import Thread
 
 import pytest
@@ -18,93 +15,10 @@ from hegel.__main__ import StdioTransport, main, run_server_stdio
 from tests.client import Client, ClientConnection
 
 
-@pytest.fixture
-def socket_path():
-    # Socket paths are limit to 104 characters on macos. This precludes using
-    # the tmp_dir pytest fixture, which creates a longer path. We'll handroll
-    # our own fixture that provides a shorter path.
-    #
-    # See https://unix.stackexchange.com/questions/367008.
-    with tempfile.TemporaryDirectory() as d:
-        yield Path(d) / "test.sock"
-
-
-@contextlib.contextmanager
-def _client_and_server(socket_path, *args, env=None):
-    """Start the CLI server and yield a connected Client."""
-
-    def run_cli():
-        if env:
-            old_env = {}
-            for k, v in env.items():
-                old_env[k] = os.environ.get(k)
-                os.environ[k] = v
-        try:
-            CliRunner().invoke(
-                main,
-                [str(socket_path), *args],
-                catch_exceptions=False,
-            )
-        finally:
-            if env:
-                for k, v in old_env.items():
-                    if v is None:
-                        os.environ.pop(k, None)
-                    else:
-                        os.environ[k] = v
-
-    t = Thread(target=run_cli, daemon=True)
-    t.start()
-
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        if not socket_path.exists():
-            time.sleep(0.01)
-            continue
-
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        try:
-            sock.connect(str(socket_path))
-        except (ConnectionRefusedError, FileNotFoundError, OSError):
-            sock.close()
-            time.sleep(0.01)
-            continue
-
-        with ClientConnection(sock) as conn:
-            yield Client(conn)
-        t.join(timeout=5)
-        return
-
-    raise RuntimeError(f"timed out waiting for socket at {socket_path}")
-
-
 def test_version():
     result = CliRunner().invoke(main, ["--version"])
     version = importlib.metadata.version("hegel-core")
     assert result.output.strip() == f"hegel (version {version})"
-
-
-@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets not available")
-@pytest.mark.parametrize("verbosity", ["normal", "verbose", "debug"])
-def test_cli(socket_path, verbosity):
-    with _client_and_server(socket_path, "--verbosity", verbosity) as client:
-        client.run_test(lambda: None, test_cases=1)
-
-
-@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets not available")
-def test_cli_cleans_up_stale_socket(socket_path):
-    socket_path.touch()
-
-    with _client_and_server(socket_path) as client:
-        client.run_test(lambda: None, test_cases=1)
-
-
-@pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="Unix sockets not available")
-def test_run_server_with_test_mode(socket_path):
-    with _client_and_server(
-        socket_path, env={"HEGEL_PROTOCOL_TEST_MODE": "empty_test"}
-    ) as client:
-        client.run_test(lambda: None, test_cases=1)
 
 
 # --- StdioTransport tests ---
@@ -176,28 +90,29 @@ def test_stdio_transport_recv_none():
     transport.close()
 
 
-# --- CLI argument validation tests ---
+# --- CLI tests ---
 
 
-def test_cli_missing_socket_path():
-    result = CliRunner().invoke(main, [])
-    assert result.exit_code != 0
-    assert "Socket path is required" in result.output
-
-
-def test_cli_stdio_with_socket_path():
-    result = CliRunner().invoke(main, ["--stdio", "/tmp/bogus.sock"])
-    assert result.exit_code != 0
-    assert "Cannot specify a socket path" in result.output
-
-
-def test_cli_stdio_calls_run_server_stdio(monkeypatch):
+def test_cli_stdio_flag_is_accepted(monkeypatch):
+    """--stdio is kept for compatibility but is a no-op (stdio is the only mode)."""
     called = []
     monkeypatch.setattr(
         "hegel.__main__.run_server_stdio",
         lambda **kwargs: called.append(kwargs),
     )
     result = CliRunner().invoke(main, ["--stdio"])
+    assert result.exit_code == 0
+    assert len(called) == 1
+
+
+def test_cli_no_stdio_flag_still_uses_stdio(monkeypatch):
+    """Without --stdio the server still runs in stdio mode."""
+    called = []
+    monkeypatch.setattr(
+        "hegel.__main__.run_server_stdio",
+        lambda **kwargs: called.append(kwargs),
+    )
+    result = CliRunner().invoke(main, [])
     assert result.exit_code == 0
     assert len(called) == 1
 


### PR DESCRIPTION
We no longer use this, so removing it as dead code. We still accept --stdio for now as a compatibility layer until we've updated the clients.

<details>
<summary>Implementation notes</summary>

- `src/hegel/__main__.py`: dropped the `socket_path` positional arg and the `run_server` function that bound an `AF_UNIX` socket. The CLI now always runs `run_server_stdio`. The `--stdio` flag is still accepted but ignored.
- `src/hegel/protocol/connection.py`: updated the `Connection` docstring to describe stdin/stdout as the transport.
- `tests/test_main.py`: removed the unix-socket-based CLI tests and the `_client_and_server` helper; replaced the old `--stdio` test with two cases covering both `--stdio` and bare invocation routing through `run_server_stdio`.
- `docs/library-api.md` and `.claude/CLAUDE.md`: rewrote the connection-lifecycle and overview sections to describe the subprocess+stdio transport, and noted that `--stdio` is a no-op.
- `RELEASE.md`: minor release note describing the removal and the `--stdio` compatibility shim.

Verified locally: `just test`, `uv run ruff check .`, `uv run mypy src/`, `uv run shed`, and `just coverage` (100% branch).

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)