### PR TITLE
Write conformance test metrics for every data status

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This release tweaks how our conformance tests write metrics.

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -22,6 +22,7 @@ from hypothesis import (
 )
 from hypothesis.errors import InvalidArgument
 from hypothesis.internal import charmap
+from hypothesis.internal.conjecture.data import Status
 
 
 def _can_encode(codec: str) -> bool:
@@ -230,7 +231,7 @@ class ConformanceTest(ABC):
                     f"stderr: {result.stderr}",
                 )
 
-            metrics_list = [
+            metrics = [
                 json.loads(line)
                 for line in metrics_file.read_text(encoding="utf-8").split("\n")
                 if line
@@ -238,14 +239,19 @@ class ConformanceTest(ABC):
 
             server_metrics_text = server_metrics_file.read_text(encoding="utf-8")
             if server_metrics_text:
-                server_metrics_list = [
+                server_metrics = [
                     json.loads(line) for line in server_metrics_text.split("\n") if line
                 ]
-                assert len(server_metrics_list) == len(metrics_list)
-                for client_m, server_m in zip(
-                    metrics_list, server_metrics_list, strict=True
-                ):
+                assert len(server_metrics) == len(metrics)
+                paired = []
+                for client_m, server_m in zip(metrics, server_metrics, strict=True):
+                    server_m["status"] = Status(server_m["status"])
+                    # skip these for now, we might do something with them in the future
+                    if server_m["status"] in (Status.INVALID, Status.OVERRUN):
+                        continue
                     client_m.update(server_m)
+                    paired.append(client_m)
+                metrics = paired
             elif not self.skip_server_metrics:
                 raise RuntimeError(
                     "Server metrics file is empty. The library binary should "
@@ -264,7 +270,7 @@ class ConformanceTest(ABC):
             server_metrics_file.unlink(missing_ok=True)
             run_metrics_file.unlink(missing_ok=True)
 
-        self.validate(metrics_list, params)
+        self.validate(metrics, params)
 
 
 class ErrorHandlingConformance(ConformanceTest):

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -219,15 +219,6 @@ class HegelState:
                         return None
                     elif command == "mark_complete":
                         done = True
-                        server_metrics_file = os.environ.get(
-                            "CONFORMANCE_SERVER_METRICS_FILE"
-                        )
-                        if server_metrics_file is not None:
-                            with open(server_metrics_file, "a", encoding="utf-8") as mf:
-                                mf.write(
-                                    json.dumps({"generate_call_count": generate_count})
-                                    + "\n"
-                                )
                         status = Status[message["status"]]
                         origin = message.get("origin")
                         if status is Status.VALID:
@@ -300,7 +291,23 @@ class HegelState:
                     self.flaky_error = e
                     raise
 
-            test_case_stream.handle_requests(handle_client_request, until=lambda: done)
+            try:
+                test_case_stream.handle_requests(
+                    handle_client_request, until=lambda: done
+                )
+            finally:
+                server_metrics_file = os.environ.get("CONFORMANCE_SERVER_METRICS_FILE")
+                if server_metrics_file is not None:
+                    with open(server_metrics_file, "a", encoding="utf-8") as mf:
+                        mf.write(
+                            json.dumps(
+                                {
+                                    "generate_call_count": generate_count,
+                                    "status": int(data.status),
+                                }
+                            )
+                            + "\n"
+                        )
 
 
 def run_server_on_connection(connection: Connection) -> None:


### PR DESCRIPTION
We previously only wrote server metrics when we received `mark_complete`. This notably does not include INVALID, OVERRUN, or INTERESTING data statuses.

This was born from a back and forth. I initially saw `len(server_metrics_list) == len(metrics_list)` error because a test case got filtered out, which bubbled up in the client (go, in this case, but could have been any) and exited the test case before the client wrote a metric. As for the server, it marked that test case as invalid and wrote a server metric. Inconsistency. (same with OVERRUN).

We could fix this by not writing server metrics for INVALID or OVERRUN. I don't like this, because I think we will want to have conformance tests over more than just VALID test cases.

I've chosen to enforce a strict relationship: every test case, regardless of status/outcome, writes a metric. (this is quite similar to the guarantees made by the observability api). This requirement is made of both the client and the server. The server is this PR. The client can implement this with a try/finally or equivalent.