### PR TITLE
claude: Tag one_of wire responses with branch index

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,3 +13,5 @@ value
 `index` is the 0-based position of the branch in `generators`. The schema shape itself is unchanged.
 
 This lets client libraries dispatch per-branch transforms directly from the protocol response, replacing a tagged-tuple workaround that each library was implementing on top of the old wire format. The change requires a coordinated update of every client library: older libraries paired with this server (or this version's libraries paired with an older server) will misinterpret `one_of` responses.
+
+The protocol version is bumped from `0.10` to `0.11` so mismatched-version clients fail cleanly at handshake instead of silently misdecoding responses.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,15 @@
+RELEASE_TYPE: minor
+
+This release changes the wire response for `one_of` schemas to include the index of the branch that produced the value:
+
+```
+# before: server emits the value directly
+value
+
+# after: server emits a 2-element list of (index, value)
+[index, value]
+```
+
+`index` is the 0-based position of the branch in `generators`. The schema shape itself is unchanged.
+
+This lets client libraries dispatch per-branch transforms directly from the protocol response, replacing a tagged-tuple workaround that each library was implementing on top of the old wire format. The change requires a coordinated update of every client library: older libraries paired with this server (or this version's libraries paired with an older server) will misinterpret `one_of` responses.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,3 @@
 RELEASE_TYPE: minor
 
-This release changes the wire response for `one_of` schemas to include the index of the branch that produced the value:
-
-```
-# before: server emits the value directly
-value
-
-# after: server emits a 2-element list of (index, value)
-[index, value]
-```
-
-`index` is the 0-based position of the branch in `generators`. The schema shape itself is unchanged.
-
-This lets client libraries dispatch per-branch transforms directly from the protocol response, replacing a tagged-tuple workaround that each library was implementing on top of the old wire format. The change requires a coordinated update of every client library: older libraries paired with this server (or this version's libraries paired with an older server) will misinterpret `one_of` responses.
-
-The protocol version is bumped from `0.10` to `0.11` so mismatched-version clients fail cleanly at handshake instead of silently misdecoding responses.
+This release changes the `one_of` protocol request to return a tuple of `[index, value]`, rather than just `value`.

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -100,7 +100,7 @@ A generator is basic (i.e. has a schema and optional transform) in these cases:
 | `lists(elements)` | If `elements` is basic | `{"type": "list", "elements": ..., ...}` | Applies element transform to each item (if any) |
 | `tuples(e1, e2, ...)` | If ALL elements are basic | `{"type": "tuple", "elements": [...]}` | Applies each element's transform (if any) |
 | `dicts(keys, values)` | If both are basic | `{"type": "dict", "keys": ..., "values": ..., ...}` | Applies key/value transforms, converts pairs to dict |
-| `one_of(g1, g2, ...)` | If ALL branches are basic | `{"one_of": [...]}` | See below |
+| `one_of(g1, g2, ...)` | If ALL branches are basic | `{"type": "one_of", "generators": [...]}` | Dispatches per-branch transform on the response index. See below |
 | `optional(element)` | If `element` is basic | Via `one_of(just(None), element)` | Via one_of |
 | Format generators (emails, urls, etc.) | Always | `{"type": "email"}` etc. | None |
 | `from_regex(pattern)` | Always | `{"type": "regex", ...}` | None |
@@ -328,7 +328,7 @@ These generators produce formatted strings.
 | `emails()` | `{"type": "email"}` |
 | `urls()` | `{"type": "url"}` |
 | `domains()` | `{"type": "domain", "max_length": <int>}` |
-| `ip_addresses()` | `{"type": "ipv4"}`, `{"type": "ipv6"}`, or `{"one_of": [{"type": "ipv4"}, {"type": "ipv6"}]}` |
+| `ip_addresses()` | `{"type": "ipv4"}`, `{"type": "ipv6"}`, or `{"type": "one_of", "generators": [{"type": "ipv4"}, {"type": "ipv6"}]}` |
 | `dates()` | `{"type": "date"}` |
 | `times()` | `{"type": "time"}` |
 | `datetimes()` | `{"type": "datetime"}` |
@@ -478,42 +478,41 @@ Choose from one of several generators.
 **Parameters:**
 - `generators`: Two or more generators.
 
-**When ALL generators are basic with no transforms (identity):**
-
-Returns a basic generator with a simple one_of schema.
-
-Schema:
+**Schema:**
 ```json
-{"one_of": [<schema1>, <schema2>, ...]}
+{"type": "one_of", "generators": [<schema1>, <schema2>, ...]}
 ```
 
-No transform needed — the server directly generates a value from one of the
-schemas.
+The schema shape is the same regardless of whether any branches have
+transforms.
 
-**When ALL generators are basic but some have transforms:**
-
-Returns a basic generator using **tagged tuples**. Each branch becomes a
-tagged tuple `[tag, value]` where `tag` is a constant integer identifying
-the branch.
-
-Schema:
-```json
-{
-  "one_of": [
-    {"type": "tuple", "elements": [{"constant": 0}, <schema1>]},
-    {"type": "tuple", "elements": [{"constant": 1}, <schema2>]},
-    ...
-  ]
-}
+**Wire response:**
+```
+[index, value]
 ```
 
-Transform: Reads the tag to determine which branch was selected, then applies
-that branch's transform to the value.
+A 2-element list where `index` is the 0-based branch index and `value`
+is the value drawn from `generators[index]`. The index is always present
+on the wire — even when no branch has a transform.
+
+**Library-side handling:**
+
+- Build a per-branch transform table aligned to `generators`. For branches
+  without a transform, store identity.
+- On receive, unpack `[index, value]`, apply `transforms[index]` to `value`,
+  and return that.
+- The index is an internal protocol detail — never surface it to user code.
+
+**When ALL generators are basic:**
+
+Returns a basic generator using the schema above. One protocol request per
+draw; the library dispatches the per-branch transform using the index.
 
 **When any generator is not basic:**
 
 Falls back to compositional generation: generates an index, then delegates
-to the selected generator. Wrapped in a span with label `ONE_OF`.
+to the selected generator. Wrapped in a span with label `ONE_OF`. This path
+is unchanged.
 
 ### `optional` / `optional_`
 

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -700,11 +700,16 @@ class OneOfConformance(ConformanceTest):
 
     Uses non-overlapping integer ranges as branches so validation can
     determine which branch produced each value. Three modes exercise
-    the three oneOf implementation paths:
+    the two oneOf implementation paths:
 
-    - basic: all branches are basic generators (single combined schema)
-    - map_negate: branches mapped through negation (single combined schema)
-    - filter_even: branches filtered to even values only (span protocol)
+    - basic: all branches are basic generators; uses the single combined
+      schema path
+    - map_negate: branches mapped through negation; still all-basic, so
+      it also uses the single combined schema path (the per-branch
+      transform is dispatched on the branch index returned by the
+      server)
+    - filter_even: branches filtered to even values only, which is
+      non-basic, so it falls back to the compositional span path
 
     Validates both correctness (values in expected ranges) and that the
     correct protocol path was used (single schema vs. multiple requests).

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -24,7 +24,7 @@ from hegel.protocol.utils import (
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
 
-PROTOCOL_VERSION = "0.10"
+PROTOCOL_VERSION = "0.11"
 HANDSHAKE_STRING = b"hegel_handshake_start"
 
 

--- a/src/hegel/schema.py
+++ b/src/hegel/schema.py
@@ -55,7 +55,12 @@ def _from_schema(schema: dict[str, Any]) -> SearchStrategy[Any]:
     if schema_type == "sampled_from":
         return st.sampled_from(schema["values"])
     if schema_type == "one_of":
-        return st.one_of([_from_schema(s) for s in schema["generators"]])
+        return st.one_of(
+            [
+                st.tuples(st.just(i), _from_schema(s))
+                for i, s in enumerate(schema["generators"])
+            ]
+        )
     if schema_type == "null":
         return st.none()
     if schema_type == "boolean":

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -331,11 +331,43 @@ def test_sampled_from():
 
 
 def test_one_of():
+    def check(v):
+        if not (isinstance(v, tuple) and len(v) == 2):
+            return False
+        index, value = v
+        if index == 0:
+            return isinstance(value, bool)
+        if index == 1:
+            return value is None
+        return False
+
     assert_all_examples(
         from_schema(
             {"type": "one_of", "generators": [{"type": "boolean"}, {"type": "null"}]}
         ),
-        lambda x: x is None or isinstance(x, bool),
+        check,
+    )
+
+
+def test_one_of_tuple_structure():
+    assert_all_examples(
+        from_schema(
+            {
+                "type": "one_of",
+                "generators": [
+                    {"type": "integer"},
+                    {"type": "boolean"},
+                    {"type": "null"},
+                ],
+            }
+        ),
+        lambda v: (
+            isinstance(v, tuple)
+            and len(v) == 2
+            # bool is a subclass of int in Python, but the index must be a plain int
+            and type(v[0]) is int
+            and 0 <= v[0] <= 2
+        ),
     )
 
 


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

The wire response for `one_of` schemas now includes the index of the branch that produced the value: the server emits `[index, value]` instead of `value`. The `{"type": "one_of", "generators": [...]}` schema shape is unchanged.

Today, when a `one_of` schema has per-branch transforms (e.g. each branch is a different `map`), every client library wraps each child schema in a tagged tuple `[constant(i), child_schema]` so it can recover which branch produced the value and apply the right transform. That's a server-side responsibility being implemented five times in client libraries. Lifting it into the protocol lets every library drop the workaround.

### Changes

- `src/hegel/schema.py` — `_from_schema` returns `st.one_of([st.tuples(st.just(i), _from_schema(s)) for i, s in enumerate(...)])` for `one_of`.
- `tests/test_schema.py` — `test_one_of` updated for the new tuple shape and asserts each branch's index/value pairing. Adds `test_one_of_tuple_structure` for explicit structural coverage. 100% branch coverage maintained.
- `src/hegel/conformance.py` — `OneOfConformance` docstring rewritten to describe the two implementation paths (combined-schema vs span fallback). No code change; `metrics["value"]` is recorded by libraries after they unpack `[index, value]`.
- `docs/library-api.md` — `one_of` section rewritten: schema unchanged, wire response is `[index, value]`, libraries dispatch the per-branch transform on the index. Tagged-tuple section removed. Summary table and the `ip_addresses` row updated to use the canonical `{"type": "one_of", ...}` form.
- `RELEASE.md` — `RELEASE_TYPE: minor` describing the wire change.

### Coordinated rollout

This PR is the source of a coordinated rollout. Five client libraries (`hegel-typescript`, `hegel-go`, `hegel-rust`, `hegel-cpp`, `hegel-ocaml`) have parallel PRs that drop their tagged-tuple workaround and dispatch transforms on the new index. They are wire-incompatible with the current published `hegel`, so:

1. This PR merges first.
2. A new `hegel` is published to PyPI.
3. Each library PR's conformance CI passes once it picks up the new `hegel`.

There are no expected CI failures on this PR itself. Until the libraries pick up the new `hegel`, their conformance CI is expected to fail — that is the only place breakage shows up during the rollout window.

</details>
