### PR TITLE
claude: whitelist .claude in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 .direnv/
 result
 *.egg-info
-.claude/settings.local.json
 build/
 external
 .devcontainer
@@ -20,17 +19,16 @@ htmlcov/
 error.log
 dist/
 
-.claude/reliability-config.yml
-.claude/reliability-config.yaml
-.claude/*.local.md
-.claude/*.local.json
-.claude/*.local
-CLAUDE.local.md
-.claude/local/
+# whitelist .claude files, rather than blacklist. Some local claude files
+# (skills, agents) have to live in .claude - as opposed to eg CLAUDE.local.md,
+# which we gitignore at the top level.
+.claude/*
+!.claude/CLAUDE.md
+!.claude/skills/
+.claude/skills/*
+!.claude/skills/changelog/
+!.claude/skills/writing-conformance-tests/
 
-# claude-reliability managed
-.claude/bin/
-.claude/*.local.md
-.claude/*.local.json
-.claude/*.local
+CLAUDE.local.md
+
 .claude-reliability/


### PR DESCRIPTION
<details><summary>Claude-written description</summary>

Switch the `.claude/` section of `.gitignore` from a blacklist (`.claude/settings.local.json`, `.claude/reliability-config.yml`, `.claude/*.local.*`, `.claude/local/`, `.claude/bin/`, etc.) to a whitelist. Local files (skills, agents, settings, plans) inside `.claude/` are now untracked by default; only explicitly-allowed files are committed:

- `.claude/CLAUDE.md`
- `.claude/skills/changelog/` (recursively)
- `.claude/skills/writing-conformance-tests/` (recursively)

Top-level `CLAUDE.local.md` continues to be gitignored at the top level. `.claude-reliability/` (sibling directory, not under `.claude/`) is unchanged.

**Adding new local skills**: any new `.claude/skills/<other-name>/` is ignored automatically. **Local notes inside an explicitly-tracked skill** (e.g. `.claude/skills/writing-conformance-tests/scratch.md`) will be tracked — that's accepted granularity.

### Deviation from the slate spec

The slate's per-repo task description listed `.claude/changelog-guidance.md` as a tracked file, but that file does not exist in this repo — the changelog guidance lives in `.claude/skills/changelog/SKILL.md`. I omitted the `!.claude/changelog-guidance.md` line and instead added `!.claude/skills/changelog/` to whitelist the actual location. Verified via `git ls-files .claude/` that all three originally-tracked files (`CLAUDE.md`, `skills/changelog/SKILL.md`, `skills/writing-conformance-tests/SKILL.md`) remain tracked.

### No `RELEASE.md`

The `check-release` CI job only fires when files under `src/` change (per `.github/scripts/release.py`). This is `.gitignore`-only, so no `RELEASE.md` is required.

### Self-review notes

The `code-reviewer` subagent flagged that whitelisting whole skill directories means future files inside `changelog/` or `writing-conformance-tests/` are tracked-by-default. This is intentional per the slate spec ("accepted granularity") and applied uniformly across all 8 repos in this slate.

</details>
