### PR TITLE
Forward phases parameter to Hypothesis settings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,5 @@
 RELEASE_TYPE: minor
 
 This release adds support for the `phases` parameter in the `run_test` protocol message,
-allowing hegel-rust clients to control which Hypothesis phases run (e.g. `generate`,
-`shrink`, `reuse`, `target`, `explicit`, `explain`). An unknown phase name now returns
-an error rather than being silently ignored.
+allowing clients to control which Hypothesis phases run (e.g. `generate`, `shrink`,
+`reuse`, `target`, `explicit`, `explain`).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds support for the `phases` parameter in the `run_test` protocol message,
+allowing hegel-rust clients to control which Hypothesis phases run (e.g. `generate`,
+`shrink`, `reuse`, `target`, `explicit`, `explain`). An unknown phase name now returns
+an error rather than being silently ignored.

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -24,7 +24,7 @@ from hegel.protocol.utils import (
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
 
-PROTOCOL_VERSION = "0.12"
+PROTOCOL_VERSION = "0.13"
 HANDSHAKE_STRING = b"hegel_handshake_start"
 
 

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -9,7 +9,7 @@ from random import Random
 from typing import Any
 
 import cbor2
-from hypothesis import HealthCheck, settings
+from hypothesis import HealthCheck, Phase, settings
 from hypothesis.control import BuildContext
 from hypothesis.core import decode_failure, encode_failure
 from hypothesis.database import DirectoryBasedExampleDatabase
@@ -339,6 +339,7 @@ def run_server_on_connection(connection: Connection) -> None:
                             ),
                             derandomize=message.get("derandomize", False),
                             database=message.get("database", not_set),
+                            phases=message.get("phases"),
                         ),
                     )
                     connection.control_stream.write_reply(packet.message_id, True)
@@ -421,6 +422,16 @@ def _single_test_case(
         raise
 
 
+_PHASE_MAP: dict[str, Phase] = {
+    "explicit": Phase.explicit,
+    "reuse": Phase.reuse,
+    "generate": Phase.generate,
+    "target": Phase.target,
+    "shrink": Phase.shrink,
+    "explain": Phase.explain,
+}
+
+
 def _run_test(
     connection: Connection,
     stream: Stream,
@@ -432,6 +443,7 @@ def _run_test(
     suppress_health_check: list[str] | None,
     derandomize: bool,
     database: str | UniqueIdentifier | None,
+    phases: list[str] | None = None,
 ) -> dict[str, Any]:
     """Run a single test using ConjectureRunner.
 
@@ -489,12 +501,15 @@ def _run_test(
         if isinstance(database, str):
             database = DirectoryBasedExampleDatabase(database)  # type: ignore
 
+        phase_list = [_PHASE_MAP[p] for p in (phases or []) if p in _PHASE_MAP] or None
+
         settings_kwargs = {
             "deadline": None,
             "max_examples": test_cases,
             "suppress_health_check": suppress,
             "backend": "hypothesis-urandom" if antithesis else "hypothesis",
             **({} if database is not_set else {"database": database}),
+            **({"phases": phase_list} if phase_list is not None else {}),
         }
 
         state = HegelState(connection, stream)

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -422,16 +422,6 @@ def _single_test_case(
         raise
 
 
-_PHASE_MAP: dict[str, Phase] = {
-    "explicit": Phase.explicit,
-    "reuse": Phase.reuse,
-    "generate": Phase.generate,
-    "target": Phase.target,
-    "shrink": Phase.shrink,
-    "explain": Phase.explain,
-}
-
-
 def _run_test(
     connection: Connection,
     stream: Stream,
@@ -501,7 +491,29 @@ def _run_test(
         if isinstance(database, str):
             database = DirectoryBasedExampleDatabase(database)  # type: ignore
 
-        phase_list = [_PHASE_MAP[p] for p in (phases or []) if p in _PHASE_MAP] or None
+        phase_list = None
+        for name in phases or []:
+            try:
+                phase = Phase(name)
+            except ValueError:
+                valid = [p.value for p in Phase]
+                result: dict[str, Any] = {
+                    "passed": False,
+                    "test_cases": 0,
+                    "valid_test_cases": 0,
+                    "invalid_test_cases": 0,
+                    "interesting_test_cases": 0,
+                    "seed": str(seed),
+                    "error": (
+                        f"Unknown phase: {name!r}. "
+                        f"Valid phases are: {valid}"
+                    ),
+                }
+                stream.send_request({"event": "test_done", "results": result}).get()
+                return result
+            if phase_list is None:
+                phase_list = []
+            phase_list.append(phase)
 
         settings_kwargs = {
             "deadline": None,

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -497,20 +497,19 @@ def _run_test(
                 phase = Phase(name)
             except ValueError:
                 valid = [p.value for p in Phase]
-                result: dict[str, Any] = {
+                error_result: dict[str, Any] = {
                     "passed": False,
                     "test_cases": 0,
                     "valid_test_cases": 0,
                     "invalid_test_cases": 0,
                     "interesting_test_cases": 0,
                     "seed": str(seed),
-                    "error": (
-                        f"Unknown phase: {name!r}. "
-                        f"Valid phases are: {valid}"
-                    ),
+                    "error": f"Unknown phase: {name!r}. Valid phases are: {valid}",
                 }
-                stream.send_request({"event": "test_done", "results": result}).get()
-                return result
+                stream.send_request(
+                    {"event": "test_done", "results": error_result}
+                ).get()
+                return error_result
             if phase_list is None:
                 phase_list = []
             phase_list.append(phase)

--- a/tests/client/client.py
+++ b/tests/client/client.py
@@ -121,6 +121,7 @@ class Client:
         database_key: bytes | None = None,
         derandomize: bool = False,
         database: str | None | UniqueIdentifier = not_set,
+        phases: list[str] | None = None,
     ) -> None:
         """Run a property test."""
 
@@ -139,6 +140,8 @@ class Client:
             message["database"] = database
         if suppress_health_check:
             message["suppress_health_check"] = suppress_health_check
+        if phases is not None:
+            message["phases"] = phases
 
         with self.__lock:
             self._control.send_request(message)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -511,6 +511,16 @@ def test_bad_health_check_name(client):
         client.run_test(test, test_cases=10, suppress_health_check=["not_a_real_check"])
 
 
+def test_bad_phase_name(client):
+    """Sending an invalid phase name reports a clear error."""
+
+    def test():
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
+
+    with pytest.raises(ValueError, match=r"Unknown phase.*'not_a_real_phase'"):
+        client.run_test(test, test_cases=10, phases=["not_a_real_phase"])
+
+
 def test_data_too_large_detected(client, monkeypatch):
     """Generating too much data per test case triggers test_cases_too_large.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -527,7 +527,7 @@ def test_phases_restricts_run(client):
     def test():
         generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
 
-    client.run_test(test, test_cases=10, phases=["generate"])
+    client.run_test(test, test_cases=10, phases=["reuse", "generate", "shrink"])
     assert client.last_result["passed"]
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -521,6 +521,16 @@ def test_bad_phase_name(client):
         client.run_test(test, test_cases=10, phases=["not_a_real_phase"])
 
 
+def test_phases_restricts_run(client):
+    """Passing a phases list is accepted and restricts which phases run."""
+
+    def test():
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
+
+    client.run_test(test, test_cases=10, phases=["generate"])
+    assert client.last_result["passed"]
+
+
 def test_data_too_large_detected(client, monkeypatch):
     """Generating too much data per test case triggers test_cases_too_large.
 


### PR DESCRIPTION
As part of https://github.com/hegeldev/hegel-rust/pull/228 we're adding phases support for the native backend. This adds phases support for the protocol as well.

AI written info: <details>

## Summary

- Adds `Phase` to the `from hypothesis import ...` line
- Adds `phases=message.get("phases")` to the `_run_test` dispatch in `run_server_on_connection`
- Adds `_PHASE_MAP` dict mapping string names (`"generate"`, `"shrink"`, etc.) to `Phase` enum values
- Adds `phases: list[str] | None = None` parameter to `_run_test`
- Converts the string list to `Phase` enum values and passes them as `phases=` in `settings_kwargs`

## Why

The companion hegel-rust PR adds `Settings::phases(impl IntoIterator<Item = Phase>)` so Rust callers can control which Hypothesis phases run. Without this server-side change, the phases list sent by the Rust client over the CBOR protocol is silently ignored — shrinking would continue even when the Rust caller passes only `[Phase::Generate]`.

## Backwards compatibility

When no `phases` key is present in the message (all existing clients), `phase_list` is `None` and `settings_kwargs` is unchanged — Hypothesis's default phase set applies.

</details>