### PR TITLE
Add UUID support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release adds support for the `uuid` schema type, exposing Hypothesis's
+This patch adds support for the `uuid` schema type, exposing Hypothesis's
 `uuids` strategy. UUIDs are returned to the client as strings in the
 canonical hyphenated form. An optional `version` field selects a specific
 UUID version (1-5).

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,6 @@
+RELEASE_TYPE: minor
+
+This release adds support for the `uuid` schema type, exposing Hypothesis's
+`uuids` strategy. UUIDs are returned to the client as strings in the
+canonical hyphenated form. An optional `version` field selects a specific
+UUID version (1-5).

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -332,7 +332,7 @@ These generators produce formatted strings.
 
 UUID values are returned as strings in the canonical hyphenated form
 (e.g. `"f47ac10b-58cc-4372-a567-0e02b2c3d479"`). When `version` is omitted,
-the server picks a version uniformly at random.
+the server picks a version.
 
 **Basic:** Always. No transform.
 

--- a/docs/library-api.md
+++ b/docs/library-api.md
@@ -328,6 +328,11 @@ These generators produce formatted strings.
 | `dates()` | `{"type": "date"}` |
 | `times()` | `{"type": "time"}` |
 | `datetimes()` | `{"type": "datetime"}` |
+| `uuids()` | `{"type": "uuid"}` or `{"type": "uuid", "version": <1\|2\|3\|4\|5>}` |
+
+UUID values are returned as strings in the canonical hyphenated form
+(e.g. `"f47ac10b-58cc-4372-a567-0e02b2c3d479"`). When `version` is omitted,
+the server picks a version uniformly at random.
 
 **Basic:** Always. No transform.
 

--- a/src/hegel/schema.py
+++ b/src/hegel/schema.py
@@ -148,6 +148,8 @@ def _from_schema(schema: dict[str, Any]) -> SearchStrategy[Any]:
         return st.times().map(lambda t: t.isoformat())
     if schema_type == "datetime":
         return st.datetimes().map(lambda dt: dt.isoformat())
+    if schema_type == "uuid":
+        return st.uuids(version=schema.get("version")).map(str)
 
     raise ValueError(f"Unsupported schema: {schema}")
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,5 +1,6 @@
 import io
 import re
+import uuid
 from fractions import Fraction
 
 import cbor2
@@ -96,6 +97,11 @@ def primitive_hashable_schemas():
         | st.just({"type": "date"})
         | st.just({"type": "time"})
         | st.just({"type": "datetime"})
+        | st.just({"type": "uuid"})
+        | st.builds(
+            lambda v: {"type": "uuid", "version": v},
+            v=st.sampled_from([1, 2, 3, 4, 5]),
+        )
     )
 
 
@@ -304,6 +310,24 @@ def test_time():
 
 def test_datetime():
     assert_all_examples(from_schema({"type": "datetime"}), lambda x: "T" in x)
+
+
+def test_uuid():
+    def check(x):
+        if not isinstance(x, str):
+            return False
+        parsed = uuid.UUID(x)
+        return str(parsed) == x
+
+    assert_all_examples(from_schema({"type": "uuid"}), check)
+
+
+@pytest.mark.parametrize("version", [1, 2, 3, 4, 5])
+def test_uuid_version(version):
+    assert_all_examples(
+        from_schema({"type": "uuid", "version": version}),
+        lambda x: uuid.UUID(x).version == version,
+    )
 
 
 @given(st.integers() | st.text())


### PR DESCRIPTION
<details>
<summary>AI-generated implementation notes</summary>

Adds a `uuid` schema type to `from_schema`, exposing `hypothesis.strategies.uuids`. Values are returned to clients as strings in the canonical hyphenated form (e.g. `f47ac10b-58cc-4372-a567-0e02b2c3d479`). An optional `version` field selects a specific UUID version (1–5); when omitted, Hypothesis picks one.

**Schema:**

```json
{"type": "uuid"}
{"type": "uuid", "version": 4}
```

**Files changed:**
- `src/hegel/schema.py` — new `uuid` branch in `_from_schema`.
- `tests/test_schema.py` — `test_uuid` (round-trips through `uuid.UUID(x)` to confirm canonical form), parametrized `test_uuid_version` for versions 1–5, plus entries in `primitive_hashable_schemas()` so the recursive `test_from_schema` covers UUIDs nested inside lists/tuples/etc.
- `docs/library-api.md` — adds `uuids()` to the format generators table.
- `RELEASE.md` — patch release note (zerover policy: new features ship as patches; minor reserved for breaking changes).

**Checks:** ruff/shed clean, mypy clean, 207 tests pass with 100% branch coverage on both the normal and antithesis runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
</details>