### PR TITLE
Bump PROTOCOL_VERSION to 0.14

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: patch
+RELEASE_TYPE: minor
 
 This patch bumps `PROTOCOL_VERSION` to `0.14`. The previous release (0.7.1) added the `uuid` schema type without bumping the protocol, so client libraries had no way to negotiate "this server understands `uuid`" at handshake. Bumping now lets clients that emit `{"type": "uuid"}` schemas require protocol `0.14` and fail cleanly against older servers instead of getting an `Unsupported schema` error at draw time.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch bumps `PROTOCOL_VERSION` to `0.14`. The previous release (0.7.1) added the `uuid` schema type without bumping the protocol, so client libraries had no way to negotiate "this server understands `uuid`" at handshake. Bumping now lets clients that emit `{"type": "uuid"}` schemas require protocol `0.14` and fail cleanly against older servers instead of getting an `Unsupported schema` error at draw time.

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -24,7 +24,7 @@ from hegel.protocol.utils import (
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
 
-PROTOCOL_VERSION = "0.13"
+PROTOCOL_VERSION = "0.14"
 HANDSHAKE_STRING = b"hegel_handshake_start"
 
 


### PR DESCRIPTION

<details>
<summary>AI-generated context</summary>

`uuid` was added as a schema type in 0.7.1 without a protocol bump, so client libraries that emit `{"type": "uuid"}` have no way to negotiate at handshake — they just get `Unsupported schema` from a 0.7.0 server at draw time. Bumping `PROTOCOL_VERSION` to `0.14` lets uuid-emitting clients require >= 0.14 and fail cleanly at handshake instead.

Triggered while updating hegel-rust PR #239 (`extract/uuids-generator`) to use the new server-side uuid schema: the test-min-protocol CI job there installs the lowest hegel-core that speaks the declared min protocol, and on the current `versions.json` mapping `0.13 → 0.7.0` that's a server without uuid.

### Changes
- `PROTOCOL_VERSION`: `0.13` → `0.14`
- New `RELEASE.md` (patch) explaining the gap and the fix.

### Verified
- `uv run pytest tests/` — 207 passed, no new warnings.

</details>