### PR TITLE
claude: add observability support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: patch
+
+This patch adds support for Hypothesis's observability feature: https://hypothesis.readthedocs.io/en/latest/reference/integrations.html#observability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     "cbor2>=5.8.0,<6.0.0",
     "click>=8.3.1,<9.0.0",
-    "hypothesis>=6.148.5,<7.0.0",
+    "hypothesis==6.152.4",
 ]
 
 [dependency-groups]

--- a/src/hegel/schema.py
+++ b/src/hegel/schema.py
@@ -111,10 +111,7 @@ def _from_schema(schema: dict[str, Any]) -> SearchStrategy[Any]:
             schema["pattern"],
             fullmatch=schema.get("fullmatch", False),
             alphabet=(
-                # hypothesis typing bug, I think
-                None
-                if alphabet_schema is None
-                else st.characters(**alphabet_schema)  # type: ignore
+                None if alphabet_schema is None else st.characters(**alphabet_schema)
             ),
         )
     if schema_type == "list":

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -3,6 +3,7 @@ import itertools
 import json
 import os
 import random
+import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
 from random import Random
@@ -29,6 +30,13 @@ from hypothesis.internal.conjecture.providers import (
 )
 from hypothesis.internal.conjecture.shrinker import sort_key
 from hypothesis.internal.conjecture.utils import calc_label_from_name, many
+from hypothesis.internal.observability import (
+    InfoObservation,
+    deliver_observation,
+    make_testcase,
+    observability_enabled,
+)
+from hypothesis.statistics import describe_statistics
 
 from hegel.protocol import Connection, ProtocolError, Stream
 from hegel.schema import _encode_value, from_schema
@@ -167,27 +175,60 @@ class HegelState:
         self,
         connection: Connection,
         stream: Stream,
-        *,
-        is_final: bool = False,
     ):
         self._connection = connection
         self._stream = stream
-        self._is_final = is_final
         self.flaky_error: Flaky | None = None
+        self._run_start = time.time()
+        self._timing_features: dict[str, float] = {}
+        # Late-bound by ``_run_test`` after the runner is constructed (the
+        # runner needs ``execute_once_for_engine`` as its test function, so
+        # we can't pass it to ``HegelState.__init__``). Read by
+        # ``execute_once_for_engine`` to tag each observation with the
+        # runner's current phase, matching hypothesis.core's
+        # ``self._runner = runner`` pattern.
+        self._runner: ConjectureRunner | None = None
 
-    def test_function(self, data: ConjectureData) -> None:
+    def execute_once_for_engine(self, data: ConjectureData) -> None:
+        try:
+            self.execute_once(data, is_final=False)
+        finally:
+            data.freeze()
+            if observability_enabled():
+                assert self._runner is not None
+                phase = self._runner._current_phase
+                backend_name = self._runner.settings.backend
+                switched = self._runner._switch_to_hypothesis_provider
+                backend_desc = (
+                    f", using backend={backend_name!r}"
+                    if backend_name != "hypothesis" and not switched
+                    else ""
+                )
+                deliver_observation(
+                    make_testcase(
+                        run_start=self._run_start,
+                        property="<unknown>",
+                        data=data,
+                        how_generated=f"during {phase} phase{backend_desc}",
+                        timing=self._timing_features,
+                        phase=phase,
+                    )
+                )
+
+    def execute_once(self, data: ConjectureData, *, is_final: bool) -> None:
+        self._timing_features = {}
         collections: dict[int, many] = {}
         variable_pools: list[Variables] = []
         collection_id_counter = itertools.count()
         generate_count = 0
 
-        with BuildContext(data, is_final=self._is_final, wrapped_test=None):  # type: ignore
+        with BuildContext(data, is_final=is_final, wrapped_test=None):  # type: ignore
             test_case_stream = self._connection.new_stream(role="Test Case")
             self._stream.send_request(
                 {
                     "event": "test_case",
                     "stream_id": test_case_stream.stream_id,
-                    "is_final": self._is_final,
+                    "is_final": is_final,
                 },
             ).get()
 
@@ -291,11 +332,21 @@ class HegelState:
                     self.flaky_error = e
                     raise
 
+            start = time.perf_counter()
             try:
                 test_case_stream.handle_requests(
                     handle_client_request, until=lambda: done
                 )
             finally:
+                # ``"overall"`` is the wall time of ``handle_requests``,
+                # conflating client test execution and protocol round-trip —
+                # the server can't separate them without per-call reports
+                # from the client. ``data.draw_times`` adds per-strategy
+                # server-side draw time.
+                self._timing_features = {
+                    "overall": time.perf_counter() - start,
+                    **data.draw_times,
+                }
                 server_metrics_file = os.environ.get("CONFORMANCE_SERVER_METRICS_FILE")
                 if server_metrics_file is not None:
                     with open(server_metrics_file, "a", encoding="utf-8") as mf:
@@ -401,10 +452,20 @@ def _single_test_case(
         )
         data.max_length = 2**64
 
-        state = HegelState(connection, stream, is_final=True)
+        state = HegelState(connection, stream)
         with contextlib.suppress(StopTest):
-            state.test_function(data)
+            state.execute_once(data, is_final=True)
         data.freeze()
+        if observability_enabled():
+            deliver_observation(
+                make_testcase(
+                    run_start=state._run_start,
+                    property="<unknown>",
+                    data=data,
+                    how_generated="explicit example",
+                    timing=state._timing_features,
+                )
+            )
 
         result: dict[str, Any] = {
             "passed": data.status is not Status.INTERESTING,
@@ -525,17 +586,28 @@ def _run_test(
 
         state = HegelState(connection, stream)
         runner = ConjectureRunner(
-            state.test_function,
+            state.execute_once_for_engine,
             settings=settings(**settings_kwargs),  # type: ignore
             random=Random(seed),
             database_key=database_key,
         )
+        state._runner = runner
         try:
             if failure_blob is not None:
                 choices = decode_failure(failure_blob)
                 data = ConjectureData.for_choices(choices)
                 with contextlib.suppress(StopTest):
-                    state.test_function(data)
+                    state.execute_once(data, is_final=False)
+                if observability_enabled():
+                    deliver_observation(
+                        make_testcase(
+                            run_start=state._run_start,
+                            property="<unknown>",
+                            data=data,
+                            how_generated="explicit example",
+                            timing=state._timing_features,
+                        )
+                    )
 
                 is_interesting = data.status is Status.INTERESTING
                 result = {
@@ -601,13 +673,35 @@ def _run_test(
             result["flaky"] = FLAKY_TEST_RESULT_MSG
 
         _write_run_metrics(result)
+        if observability_enabled() and failure_blob is None:
+            deliver_observation(
+                InfoObservation(
+                    type="info",
+                    run_start=state._run_start,
+                    property="<unknown>",
+                    title="Hegel Statistics",
+                    content=describe_statistics(runner.statistics),
+                )
+            )
+
         stream.send_request({"event": "test_done", "results": result}).get()
 
-        final_state = HegelState(connection, stream, is_final=True)
-
         for choices in interesting_choices:
+            data = ConjectureData.for_choices(choices)
             with contextlib.suppress(StopTest):
-                final_state.test_function(ConjectureData.for_choices(choices))
+                state.execute_once(data, is_final=True)
+            if observability_enabled():
+                origin = data.interesting_origin
+                deliver_observation(
+                    make_testcase(
+                        run_start=state._run_start,
+                        property="<unknown>",
+                        data=data,
+                        how_generated="minimal failing example",
+                        timing=state._timing_features,
+                        status_reason=str(origin or "unexpected/flaky pass"),
+                    )
+                )
 
         return result
     except Exception:

--- a/tests/conformance/test_infrastructure.py
+++ b/tests/conformance/test_infrastructure.py
@@ -113,7 +113,13 @@ def test_text_conformance_test_no_surrogates(s):
 
 
 def test_text_conformance_test_surrogates():
+    # Finding a surrogate-containing string requires several params-strategy
+    # gates to align (no codec, codepoint range covers 0xD800-0xDFFF, "Cs"
+    # not excluded etc.) AND st.characters to actually emit a surrogate
+    # (only 0x800 of ~0x110000 codepoints). The product of those probabilities
+    # is small enough that the default 1000 examples is flaky — bump it.
     find_any(
         _text_from_params(no_surrogates=False),
         lambda s: any(unicodedata.category(c) == "Cs" for c in s),
+        settings=settings(max_examples=20_000),
     )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -103,7 +103,13 @@ def test_per_thread_callback_does_not_receive_server_observations(client):
     assert collected == []
 
 
-def test_passing_run_test(client):
+def test_passing_run_test(client, monkeypatch):
+    # This test asserts default-backend behavior (no "using backend" suffix in
+    # how_generated). The antithesis CI run sets ANTITHESIS_OUTPUT_DIR for the
+    # whole suite, which switches the runner to hypothesis-urandom and adds
+    # the suffix; clear it here so the default-backend assertions hold.
+    monkeypatch.delenv("ANTITHESIS_OUTPUT_DIR", raising=False)
+
     def test():
         generate_from_schema({"type": "integer", "min_value": 0, "max_value": 10_000})
         generate_from_schema({"type": "boolean"})

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,339 @@
+"""Tests for the observability emission added in server.py.
+
+These tests register observability callbacks via
+``with_observability_callback(..., all_threads=True)`` because the hegel
+server runs in a daemon thread (and dispatches ``_run_test`` onto a
+``ThreadPoolExecutor`` worker), so observations are delivered from a
+different thread than the one that registers the callback.
+
+A few of the emission sites — the per-case observation in
+``execute_once_for_engine`` after the client raises in is_final mode, the
+"minimal failing example" replay, and the "explicit example" record after
+a single_test_case failure — are delivered after the client has already
+returned. ``wait_for`` polls the captured list to bridge that gap. The
+``cutoff`` filter in ``capture_observations`` discards observations from
+*previous* runs that arrive late (their ``HegelState.run_start`` predates
+the cutoff), so a slow MFE delivery from one ``client.run_test`` call
+doesn't leak into the next call's capture.
+"""
+
+import contextlib
+import time
+from collections.abc import Callable
+
+import pytest
+from hypothesis.internal.observability import (
+    InfoObservation,
+    Observation,
+    TestCaseObservation,
+    observability_enabled,
+    with_observability_callback,
+)
+
+from tests.client import assume, generate_from_schema
+
+
+@contextlib.contextmanager
+def capture_observations():
+    """Collect every observation delivered while the block is active.
+
+    Observations whose ``run_start`` predates the block entry are filtered
+    out. The server delivers some observations *after* the client returns,
+    so a slow delivery from a previous run can race into the next capture
+    block — without this filter, those late observations would be
+    misattributed to the new run.
+    """
+    collected: list[Observation] = []
+    cutoff = time.time()
+
+    def callback(observation: Observation, _thread_id: int) -> None:
+        if observation.run_start >= cutoff:
+            collected.append(observation)
+
+    with with_observability_callback(callback, all_threads=True):  # type: ignore[arg-type]
+        yield collected
+
+
+def wait_for(condition: Callable[[], object], *, timeout: float = 2.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if condition():
+            return
+        time.sleep(0.005)
+    raise AssertionError(f"Condition not met within {timeout}s")
+
+
+def _testcases(obs):
+    return [o for o in obs if isinstance(o, TestCaseObservation)]
+
+
+def _infos(obs):
+    return [o for o in obs if isinstance(o, InfoObservation)]
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+def test_observability_disabled_by_default():
+    # No callback registered anywhere — observability_enabled() is False.
+    assert not observability_enabled()
+
+
+def test_per_thread_callback_does_not_receive_server_observations(client):
+    """The server runs ``_run_test`` on a thread-pool worker. A per-thread
+    callback registered on the test thread is never invoked for those
+    observations — hegel relies on consumers using ``all_threads=True``
+    (or the file-output callback that hypothesis registers for them when
+    ``HYPOTHESIS_EXPERIMENTAL_OBSERVABILITY`` is set, which is itself
+    ``all_threads=True``)."""
+    collected: list[Observation] = []
+
+    def cb(observation):
+        collected.append(observation)
+
+    def test():
+        generate_from_schema({"type": "integer"})
+
+    with with_observability_callback(cb):  # all_threads=False
+        assert observability_enabled()
+        client.run_test(test)
+
+    assert collected == []
+
+
+def test_passing_run_test(client):
+    def test():
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 10_000})
+        generate_from_schema({"type": "boolean"})
+
+    with capture_observations() as obs:
+        client.run_test(test)
+
+    cases = _testcases(obs)
+    infos = _infos(obs)
+
+    expected_cases = client.last_result["test_cases"]
+    assert expected_cases == 100
+    assert len(cases) == expected_cases
+
+    # Exactly one info record (Hegel Statistics).
+    assert len(infos) == 1
+    info = infos[0]
+    assert info.type == "info"
+    assert info.title == "Hegel Statistics"
+    assert info.property == "<unknown>"
+    assert isinstance(info.content, str)
+    # describe_statistics produces a per-phase summary.
+    assert "generate phase" in info.content
+
+    # All observations from one _run_test invocation share a single
+    # HegelState.run_start. (No MFE here, so no second final_state.)
+    assert len({o.run_start for o in obs}) == 1
+
+    # Per-case shape & static fields.
+    for c in cases:
+        assert c.type == "test_case"
+        assert c.property == "<unknown>"
+        assert c.representation == "<unknown>"
+        # No MFE / explicit-example records on a passing run.
+        assert c.how_generated.startswith("during ")
+        assert "phase" in c.how_generated
+        # Default backend → no backend suffix.
+        assert "using backend" not in c.how_generated
+        # Phase metadata matches the how_generated string.
+        assert c.metadata.phase is not None
+        assert c.metadata.phase in c.how_generated
+        # data_status is always populated.
+        assert c.metadata.data_status is not None
+        # OBSERVABILITY_CHOICES defaults off.
+        assert c.metadata.choice_nodes is None
+        assert c.metadata.choice_spans is None
+        # timing always carries the wall-clock "overall" key.
+        assert "overall" in c.timing
+        assert c.timing["overall"] >= 0
+
+    # At least one observation should describe the generate phase.
+    assert any("generate phase" in c.how_generated for c in cases)
+
+    # At least one passing case captured both per-draw timings.
+    passed_cases = [c for c in cases if c.status == "passed"]
+    assert any(
+        "generate:unlabeled_0" in c.timing and "generate:unlabeled_1" in c.timing
+        for c in passed_cases
+    )
+
+
+def test_failing_run_test(client):
+    def test():
+        x = generate_from_schema(
+            {"type": "integer", "min_value": 0, "max_value": 1000},
+        )
+        assert x <= 10
+
+    with capture_observations() as obs:
+        with pytest.raises(AssertionError):
+            client.run_test(test)
+        # The MFE observation is delivered after the client has already
+        # raised, so we have to wait for it.
+        wait_for(
+            lambda: any(
+                c.how_generated == "minimal failing example" for c in _testcases(obs)
+            )
+        )
+
+    cases = _testcases(obs)
+    mfes = [c for c in cases if c.how_generated == "minimal failing example"]
+    failed = [c for c in cases if c.status == "failed"]
+
+    # Exactly one MFE for a single distinct failure.
+    assert len(mfes) == 1
+    assert mfes[0].status == "failed"
+    # All observations from one client.run_test invocation — including the
+    # MFE replay — share a single run_start, so consumers can group them
+    # as one logical run.
+    assert len({o.run_start for o in obs}) == 1
+    # status_reason is the InterestingOrigin string the client supplied —
+    # for hegel that string is built as "<ExceptionType> at <file>:<line>".
+    assert "AssertionError" in mfes[0].status_reason
+
+    # At least the original failing case + the MFE replay are "failed".
+    assert len(failed) >= 2
+
+    # status_reason on a non-MFE failed case is also derived from the
+    # client-supplied origin (via data.interesting_origin), so AssertionError
+    # appears there too.
+    non_mfe_failed = [c for c in failed if c.how_generated != "minimal failing example"]
+    assert non_mfe_failed
+    assert any("AssertionError" in c.status_reason for c in non_mfe_failed)
+
+
+def test_single_test_case_passing(client):
+    def test():
+        generate_from_schema({"type": "integer"})
+
+    with capture_observations() as obs:
+        client.single_test_case(test)
+
+    cases = _testcases(obs)
+    assert len(cases) == 1
+    case = cases[0]
+    assert case.how_generated == "explicit example"
+    assert case.status == "passed"
+    # No info record from single_test_case (didn't drive the runner).
+    assert _infos(obs) == []
+
+
+def test_single_test_case_failing(client):
+    def test():
+        raise AssertionError("boom")
+
+    with capture_observations() as obs:
+        with pytest.raises(AssertionError):
+            client.single_test_case(test)
+        # Observation is delivered after the client has raised.
+        wait_for(lambda: _testcases(obs))
+
+    cases = _testcases(obs)
+    assert len(cases) == 1
+    assert cases[0].how_generated == "explicit example"
+    assert cases[0].status == "failed"
+    assert _infos(obs) == []
+
+
+def test_single_test_case_invalid_gave_up(client):
+    def test():
+        assume(False)
+
+    with capture_observations() as obs:
+        client.single_test_case(test)
+
+    cases = _testcases(obs)
+    assert len(cases) == 1
+    assert cases[0].how_generated == "explicit example"
+    assert cases[0].status == "gave_up"
+
+
+# ---------------------------------------------------------------------------
+# failure_blob — replays the blob (1 explicit example) and, if it
+# reproduces, also runs the MFE replay (1 minimal failing example).
+# ---------------------------------------------------------------------------
+
+
+def test_failure_blob_reproducing(client):
+    def test():
+        x = generate_from_schema(
+            {"type": "integer", "min_value": 0, "max_value": 1000},
+        )
+        assert x <= 10
+
+    with pytest.raises(AssertionError):
+        client.run_test(test)
+    blob = client.last_result["failure_blobs"][0]
+
+    with capture_observations() as obs:
+        with pytest.raises(AssertionError):
+            client.run_test(test, failure_blob=blob)
+        wait_for(
+            lambda: any(
+                c.how_generated == "minimal failing example" for c in _testcases(obs)
+            )
+        )
+
+    cases = _testcases(obs)
+    explicit = [c for c in cases if c.how_generated == "explicit example"]
+    mfe = [c for c in cases if c.how_generated == "minimal failing example"]
+
+    assert len(explicit) == 1
+    assert explicit[0].status == "failed"
+    assert len(mfe) == 1
+    assert mfe[0].status == "failed"
+    # failure_blob path explicitly suppresses the Hegel Statistics info
+    # record (didn't drive the runner).
+    assert _infos(obs) == []
+    # The blob replay and the subsequent MFE replay share a single
+    # run_start.
+    assert len({o.run_start for o in obs}) == 1
+
+
+# ---------------------------------------------------------------------------
+# Mixed status mapping (passed + gave_up in a single run).
+# ---------------------------------------------------------------------------
+
+
+def test_status_mapping_passed_and_gave_up(client):
+    def test():
+        x = generate_from_schema(
+            {"type": "integer", "min_value": 0, "max_value": 100},
+        )
+        assume(x % 2 == 0)
+
+    with capture_observations() as obs:
+        client.run_test(test)
+
+    statuses = {c.status for c in _testcases(obs)}
+    # Even values pass the assume; odd values are rejected (gave_up).
+    assert "passed" in statuses
+    assert "gave_up" in statuses
+
+
+# ---------------------------------------------------------------------------
+# Backend suffix in how_generated under the hypothesis-urandom backend.
+# ---------------------------------------------------------------------------
+
+
+def test_how_generated_includes_backend_under_antithesis(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANTITHESIS_OUTPUT_DIR", str(tmp_path))
+
+    def test():
+        generate_from_schema({"type": "integer", "min_value": 0, "max_value": 10_000})
+
+    with capture_observations() as obs:
+        client.run_test(test)
+
+    # Backend suffix appears only when the runner is actually using the
+    # alternative backend (i.e. _switch_to_hypothesis_provider is False).
+    assert any(
+        "using backend='hypothesis-urandom'" in c.how_generated for c in _testcases(obs)
+    )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,9 +6,12 @@ class Found(Exception):
 
 
 def find_any(strategy, condition, *, settings=None):
+    if settings is None:
+        settings = Settings()
+
     @Settings(
         settings,
-        max_examples=1000,
+        max_examples=max(1000, settings.max_examples),
         phases=set(Phase) - {Phase.shrink},
         suppress_health_check=list(HealthCheck),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -284,7 +284,7 @@ dev = [
 requires-dist = [
     { name = "cbor2", specifier = ">=5.8.0,<6.0.0" },
     { name = "click", specifier = ">=8.3.1,<9.0.0" },
-    { name = "hypothesis", specifier = ">=6.148.5,<7.0.0" },
+    { name = "hypothesis", specifier = "==6.152.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -300,15 +300,15 @@ dev = [
 
 [[package]]
 name = "hypothesis"
-version = "6.148.7"
+version = "6.152.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "sortedcontainers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/5e/6a506e81d4dfefed2e838b6beaaae87b2e411dda3da0a3abf94099f194ae/hypothesis-6.148.7.tar.gz", hash = "sha256:b96e817e715c5b1a278411e3b9baf6d599d5b12207ba25e41a8f066929f6c2a6", size = 471199, upload-time = "2025-12-05T02:12:38.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/c7/3147bd903d6b18324a016d43a259cf5b4bb4545e1ead6773dc8a0374e70a/hypothesis-6.152.4.tar.gz", hash = "sha256:31c8f9ce619716f543e2710b489b1633c833586641d9e6c94cee03f109a5afc4", size = 466444, upload-time = "2026-04-27T20:18:37.594Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/55/fa5607e4a4af96dfa0e7efd81bbd130735cedd21aac70b25e06191bff92f/hypothesis-6.148.7-py3-none-any.whl", hash = "sha256:94dbd58ebf259afa3bafb1d3bf5761ac1bde6f1477de494798cbf7960aabbdee", size = 538127, upload-time = "2025-12-05T02:12:35.54Z" },
+    { url = "https://files.pythonhosted.org/packages/19/89/0f50dd0d92e8a7dffc24f69ab910ff81db89b2f082ba42682bd57695e4d2/hypothesis-6.152.4-py3-none-any.whl", hash = "sha256:e730fd93c7578182efadc7f90b3c5437ee4d55edf738930eb5043c81ac1d97e8", size = 532145, upload-time = "2026-04-27T20:18:35.043Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes https://github.com/hegeldev/hegel-core/issues/120.

Also pins our hypothesis version exactly, because we are now depending on enough hypothesis internals that I am very nervous about breakage if we leave that pin loose.

<details><summary>Claude-written description</summary>

Adds support for Hypothesis's [observability feature](https://hypothesis.readthedocs.io/en/latest/reference/integrations.html#observability) to the hegel server.

Changes:
- `HegelState` is split: `execute_once` runs the test body and is shared between the runner-driven path and the explicit/replay paths; `execute_once_for_engine` wraps it for the runner and emits a per-case `TestCaseObservation` tagged with the runner's current phase and (when applicable) the active backend.
- Per-run `InfoObservation` ("Hegel Statistics") is delivered after the runner finishes, using `describe_statistics`. Suppressed on the `failure_blob` path since that path doesn't drive the runner.
- The `_single_test_case` and explicit-example paths emit a `make_testcase` observation with `how_generated="explicit example"`; the post-run replay of interesting choices emits `how_generated="minimal failing example"` with `status_reason` derived from `data.interesting_origin`.
- Timing: `execute_once` records `overall` (wall-clock of `handle_requests`, which conflates client execution and protocol round-trip — the server can't separate them without per-call client reports) plus `data.draw_times` for per-strategy server-side timing.
- Pins hypothesis to `==6.152.4`. The observability emission uses internal Hypothesis APIs (`hypothesis.internal.observability`, `_current_phase`, `_switch_to_hypothesis_provider`, `describe_statistics`), so version-locking avoids silent breakage on minor bumps.
- Adds `tests/test_observability.py` covering: gating (default off, per-thread callback doesn't see server observations), passing runs (per-case shape, statistics info record, single shared `run_start`), failing runs and MFE replay (status_reason, count), `single_test_case` passing/failing/gave-up, `failure_blob` reproducing path, mixed `passed`/`gave_up` statuses, and the backend suffix in `how_generated` under `ANTITHESIS_OUTPUT_DIR`.

</details>
