### PR TITLE
Avoid stdio close deadlock under uv

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+RELEASE_TYPE: patch
+
+This patch fixes a stdio-server shutdown deadlock that could occur under `uv`
+when the server exited after an error while stdin remained open.

--- a/src/hegel/__main__.py
+++ b/src/hegel/__main__.py
@@ -85,7 +85,9 @@ def run_server_stdio(*, verbosity: Verbosity = Verbosity.normal) -> None:
     # Also redirect Python-level sys.stdout to stderr.
     sys.stdout = sys.stderr
 
-    protocol_reader = os.fdopen(protocol_in_fd, "rb")
+    # Keep stdin unbuffered so close() cannot block on a BufferedReader lock
+    # held by the background protocol reader thread.
+    protocol_reader = os.fdopen(protocol_in_fd, "rb", buffering=0)
     protocol_writer = os.fdopen(protocol_out_fd, "wb", buffering=0)
 
     if verbosity >= Verbosity.verbose:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,8 @@ from click.testing import CliRunner
 from hypothesis import Verbosity
 
 from hegel.__main__ import StdioTransport, main, run_server_stdio
+from hegel.protocol.connection import HANDSHAKE_STRING, PROTOCOL_VERSION
+from hegel.protocol.packet import Packet, read_packet, write_packet
 from tests.client import Client, ClientConnection
 
 
@@ -181,3 +183,45 @@ def test_run_server_stdio_debug():
 
 def test_run_server_stdio_test_mode():
     _run_stdio_test(env={"HEGEL_PROTOCOL_TEST_MODE": "empty_test"})
+
+
+def test_run_server_stdio_closes_after_error_with_open_stdin(monkeypatch):
+    monkeypatch.setenv("HEGEL_PROTOCOL_TEST_MODE", "not-a-real-mode")
+
+    with _redirect_stdio_to_pipes() as (client_read_fd, client_write_fd):
+        errors = []
+
+        def run():
+            try:
+                run_server_stdio(verbosity=Verbosity.normal)
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = Thread(target=run, daemon=True)
+        thread.start()
+
+        client_reader = os.fdopen(client_read_fd, "rb")
+        client_writer = os.fdopen(client_write_fd, "wb", buffering=0)
+        client_transport = StdioTransport(client_reader, client_writer)
+
+        try:
+            write_packet(
+                client_transport,
+                Packet(
+                    stream_id=0,
+                    message_id=1,
+                    is_reply=False,
+                    payload=HANDSHAKE_STRING,
+                ),
+            )
+            reply = read_packet(client_transport)
+            assert reply.payload == f"Hegel/{PROTOCOL_VERSION}".encode("ascii")
+
+            thread.join(timeout=2)
+            assert not thread.is_alive()
+            assert len(errors) == 1
+            assert isinstance(errors[0], ValueError)
+            assert "Unknown test mode" in str(errors[0])
+        finally:
+            client_transport.close()
+            thread.join(timeout=2)


### PR DESCRIPTION
When the stdio server exits after an error while the client still has stdin open, the background protocol reader can be blocked in BufferedReader.read(). connection.close() then closes the same reader from the main thread. Under uv, BufferedReader.close() waits for the reader lock, so the close path never returns and the hegel process hangs instead of reporting the original error.

Open the duplicated stdin fd unbuffered so close() only closes the fd and does not contend with the blocking reader thread.