### PR TITLE
Address Erlang not having inf and nan values for floats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: just check-lint
       - name: Check zizmor
         run: |
-          uv tool install zizmor
+          uv tool install zizmor==1.23.1
           zizmor --format plain .github/
 
   test:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+RELEASE_TYPE: minor
+
+This release adds `allow_nan` and `allow_infinity` boolean arguments to `FloatConformance()`. This makes it possible for clients where infinity or nan is not supported (e.g. Erlang) to run float conformance tests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
-RELEASE_TYPE: minor
+RELEASE_TYPE: patch
 
-This release adds `allow_nan` and `allow_infinity` boolean arguments to `FloatConformance()`. This makes it possible for clients where infinity or nan is not supported (e.g. Erlang) to run float conformance tests.
+This release adds the `allow_nan` and `allow_infinity` boolean arguments to `FloatConformance()`. This makes it possible for clients where infinity or nan is not supported to run float conformance tests.

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -386,6 +386,23 @@ class IntegerConformance(ConformanceTest):
 class FloatConformance(ConformanceTest):
     default_test_cases = 500  # NaN/infinity are rare, need more samples
 
+    def __init__(
+        self,
+        binary_path: str | Path,
+        test_cases: int = default_test_cases,
+        *,
+        # Erlang does not allow inf or NaN in floats, so this
+        # needs to be configurable
+        allow_infinity: bool | None = None,
+        allow_nan: bool | None = None,
+        skip_server_metrics: bool = False,
+    ):
+        super().__init__(
+            binary_path, test_cases, skip_server_metrics=skip_server_metrics
+        )
+        self.allow_infinity = allow_infinity
+        self.allow_nan = allow_nan
+
     def params_strategy(self) -> st.SearchStrategy[dict[str, Any]]:
         @st.composite
         def strategy(draw: st.DrawFn) -> dict[str, Any]:
@@ -434,17 +451,23 @@ class FloatConformance(ConformanceTest):
             # letting the library apply its own defaults (which must match
             # Hypothesis: nan disallowed when any bound is set, infinity
             # disallowed when both bounds are set).
-            allow_nan: bool | None = draw(
-                st.sampled_from(
-                    [None, False] + ([] if (use_min_value or use_max_value) else [True])
-                ),
-            )
-            allow_infinity: bool | None = draw(
-                st.sampled_from(
-                    [None, False]
-                    + ([] if (use_min_value and use_max_value) else [True])
-                ),
-            )
+            allow_nan = self.allow_nan
+            if allow_nan is None:
+                allow_nan = draw(
+                    st.sampled_from(
+                        [None, False]
+                        + ([] if (use_min_value or use_max_value) else [True])
+                    ),
+                )
+
+            allow_infinity = self.allow_infinity
+            if allow_infinity is None:
+                allow_infinity = draw(
+                    st.sampled_from(
+                        [None, False]
+                        + ([] if (use_min_value and use_max_value) else [True])
+                    ),
+                )
 
             return {
                 "min_value": min_value,

--- a/src/hegel/conformance.py
+++ b/src/hegel/conformance.py
@@ -391,8 +391,6 @@ class FloatConformance(ConformanceTest):
         binary_path: str | Path,
         test_cases: int = default_test_cases,
         *,
-        # Erlang does not allow inf or NaN in floats, so this
-        # needs to be configurable
         allow_infinity: bool | None = None,
         allow_nan: bool | None = None,
         skip_server_metrics: bool = False,


### PR DESCRIPTION
Closes #127

This PR
- adds a constructor for FloatConformance
- uses the values to constrain the float strategy

so that a client can constrain the generation of floats in conformance tests to exclude nan and inf.