### PR TITLE
Add report_multiple_failures protocol field

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,10 @@
+RELEASE_TYPE: minor
+
+This release adds a `report_multiple_failures` field to the `run_test`
+protocol message, which maps to Hypothesis's `report_multiple_bugs`
+setting. When `False`, Hypothesis collapses multi-bug runs to a single
+failing example rather than surfacing one per distinct origin; the
+default (`True`) preserves the existing behaviour.
+
+The protocol version bumps from `0.14` to `0.15` so clients can detect
+whether the server understands the new field.

--- a/src/hegel/protocol/connection.py
+++ b/src/hegel/protocol/connection.py
@@ -24,7 +24,7 @@ from hegel.protocol.utils import (
 if TYPE_CHECKING:
     from hegel.protocol.stream import Stream
 
-PROTOCOL_VERSION = "0.14"
+PROTOCOL_VERSION = "0.15"
 HANDSHAKE_STRING = b"hegel_handshake_start"
 
 

--- a/src/hegel/server.py
+++ b/src/hegel/server.py
@@ -391,6 +391,9 @@ def run_server_on_connection(connection: Connection) -> None:
                             derandomize=message.get("derandomize", False),
                             database=message.get("database", not_set),
                             phases=message.get("phases"),
+                            report_multiple_failures=message.get(
+                                "report_multiple_failures", True
+                            ),
                         ),
                     )
                     connection.control_stream.write_reply(packet.message_id, True)
@@ -495,6 +498,7 @@ def _run_test(
     derandomize: bool,
     database: str | UniqueIdentifier | None,
     phases: list[str] | None = None,
+    report_multiple_failures: bool = True,
 ) -> dict[str, Any]:
     """Run a single test using ConjectureRunner.
 
@@ -580,6 +584,7 @@ def _run_test(
             "max_examples": test_cases,
             "suppress_health_check": suppress,
             "backend": "hypothesis-urandom" if antithesis else "hypothesis",
+            "report_multiple_bugs": report_multiple_failures,
             **({} if database is not_set else {"database": database}),
             **({"phases": phase_list} if phase_list is not None else {}),
         }

--- a/tests/client/client.py
+++ b/tests/client/client.py
@@ -122,6 +122,7 @@ class Client:
         derandomize: bool = False,
         database: str | None | UniqueIdentifier = not_set,
         phases: list[str] | None = None,
+        report_multiple_failures: bool | None = None,
     ) -> None:
         """Run a property test."""
 
@@ -142,6 +143,8 @@ class Client:
             message["suppress_health_check"] = suppress_health_check
         if phases is not None:
             message["phases"] = phases
+        if report_multiple_failures is not None:
+            message["report_multiple_failures"] = report_multiple_failures
 
         with self.__lock:
             self._control.send_request(message)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -185,6 +185,15 @@ def test_run_server_stdio_test_mode():
     _run_stdio_test(env={"HEGEL_PROTOCOL_TEST_MODE": "empty_test"})
 
 
+@pytest.mark.xfail(
+    sys.platform == "win32",
+    reason=(
+        "Stdin doesn't close on Windows after a server-side error, so the "
+        "reader thread blocks instead of shutting down cleanly. "
+        "See https://github.com/hegeldev/hegel-core/issues/130."
+    ),
+    strict=False,
+)
 def test_run_server_stdio_closes_after_error_with_open_stdin(monkeypatch):
     monkeypatch.setenv("HEGEL_PROTOCOL_TEST_MODE", "not-a-real-mode")
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -398,6 +398,26 @@ def test_multiple_blobs(client):
     assert len(client.last_result["failure_blobs"]) == 2
 
 
+def test_report_multiple_failures_false_collapses_blobs(client):
+    """`report_multiple_failures=False` maps to Hypothesis's
+    `report_multiple_bugs=False`, which surfaces only the first failure
+    even when the run found several distinct ones.
+    """
+
+    def test():
+        x = generate_from_schema({"type": "integer", "min_value": 0, "max_value": 100})
+        assert x <= 10
+
+        y = generate_from_schema({"type": "integer", "min_value": -10, "max_value": -1})
+        assert y >= 0
+
+    with pytest.raises(Exception) as exc_info:
+        client.run_test(test, test_cases=50, report_multiple_failures=False)
+    # Single failure: a bare exception, not an ExceptionGroup.
+    assert not isinstance(exc_info.value, ExceptionGroup)
+    assert len(client.last_result["failure_blobs"]) == 1
+
+
 def test_derandomize_with_database_key(client):
     """Tests that derandomize=True derives seed from database_key."""
 


### PR DESCRIPTION
Although we supported reporting multiple failures, we didn't support disabling this in the protocol. This PR fixes that.